### PR TITLE
chore: bootstrap Spring Boot 3 project with Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDEs
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# OS files
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'strategic-city-simulator'

--- a/src/main/java/com/example/StrategicCitySimulatorApplication.java
+++ b/src/main/java/com/example/StrategicCitySimulatorApplication.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class StrategicCitySimulatorApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(StrategicCitySimulatorApplication.class, args);
+    }
+}

--- a/src/test/java/com/example/StrategicCitySimulatorApplicationTests.java
+++ b/src/test/java/com/example/StrategicCitySimulatorApplicationTests.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class StrategicCitySimulatorApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add Gradle build with Spring Boot 3 plugins and dependencies
- include minimal application and test classes

## Testing
- `gradle build` *(fails: Plugin [id: 'org.springframework.boot', version: '3.2.5'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b1a602a4832d98ab0a652812a358