### PR TITLE
ci: GitHub Actions로 테스트 및 Docker 빌드 파이프라인 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: strategic-city-simulator:ci
+
+      - name: Start local registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Push image to local registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker tag strategic-city-simulator:ci localhost:5000/strategic-city-simulator:${{ github.sha }}
+          docker push localhost:5000/strategic-city-simulator:${{ github.sha }}


### PR DESCRIPTION
## 요약
- PR과 main push에서 실행되는 CI 워크플로 구성
- Gradle 테스트 실행 후 Docker 이미지를 빌드
- main 브랜치 푸시 시 로컬 레지스트리에 이미지 푸시 시뮬레이션

## 테스트
- `./gradlew test` *(외부 저장소 403으로 실패)*
- `docker build -t scs:test .` *(Docker 미설치로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_6898c69c0028832d972094bd952bf476