### PR TITLE
feat: add ERD draft and JPA entity skeleton

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,0 +1,36 @@
+# ERD Draft
+
+```mermaid
+erDiagram
+    GameSession {
+        Long id
+        String difficulty
+        Integer currentMonth
+        LocalDateTime createdAt
+    }
+    Indicator {
+        Long id
+        String name
+        Integer value
+    }
+    CategoryScore {
+        Long id
+        String category
+        Integer score
+    }
+    BudgetAllocation {
+        Long id
+        String category
+        Double ratio
+    }
+    EventLog {
+        Long id
+        String type
+        String description
+        LocalDateTime occurredAt
+    }
+    GameSession ||--o{ Indicator : contains
+    GameSession ||--o{ CategoryScore : has
+    GameSession ||--o{ BudgetAllocation : allocates
+    GameSession ||--o{ EventLog : logs
+```

--- a/src/main/java/com/example/domain/BudgetAllocation.java
+++ b/src/main/java/com/example/domain/BudgetAllocation.java
@@ -1,0 +1,45 @@
+package com.example.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "budget_allocations")
+public class BudgetAllocation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private CategoryType category;
+
+    private Double ratio;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private GameSession session;
+
+    protected BudgetAllocation() {
+    }
+
+    public BudgetAllocation(CategoryType category, Double ratio, GameSession session) {
+        this.category = category;
+        this.ratio = ratio;
+        this.session = session;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public CategoryType getCategory() {
+        return category;
+    }
+
+    public Double getRatio() {
+        return ratio;
+    }
+
+    public GameSession getSession() {
+        return session;
+    }
+}

--- a/src/main/java/com/example/domain/CategoryScore.java
+++ b/src/main/java/com/example/domain/CategoryScore.java
@@ -1,0 +1,45 @@
+package com.example.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "category_scores")
+public class CategoryScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private CategoryType category;
+
+    private Integer score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private GameSession session;
+
+    protected CategoryScore() {
+    }
+
+    public CategoryScore(CategoryType category, Integer score, GameSession session) {
+        this.category = category;
+        this.score = score;
+        this.session = session;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public CategoryType getCategory() {
+        return category;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public GameSession getSession() {
+        return session;
+    }
+}

--- a/src/main/java/com/example/domain/CategoryType.java
+++ b/src/main/java/com/example/domain/CategoryType.java
@@ -1,0 +1,10 @@
+package com.example.domain;
+
+public enum CategoryType {
+    DEFENSE,
+    DIPLOMACY,
+    ECONOMY,
+    POLITICS,
+    CULTURE,
+    ENVIRONMENT
+}

--- a/src/main/java/com/example/domain/Difficulty.java
+++ b/src/main/java/com/example/domain/Difficulty.java
@@ -1,0 +1,7 @@
+package com.example.domain;
+
+public enum Difficulty {
+    EASY,
+    NORMAL,
+    HARD
+}

--- a/src/main/java/com/example/domain/EventLog.java
+++ b/src/main/java/com/example/domain/EventLog.java
@@ -1,0 +1,52 @@
+package com.example.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event_logs")
+public class EventLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String type;
+
+    private String description;
+
+    private LocalDateTime occurredAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private GameSession session;
+
+    protected EventLog() {
+    }
+
+    public EventLog(String type, String description, LocalDateTime occurredAt, GameSession session) {
+        this.type = type;
+        this.description = description;
+        this.occurredAt = occurredAt;
+        this.session = session;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+
+    public GameSession getSession() {
+        return session;
+    }
+}

--- a/src/main/java/com/example/domain/GameSession.java
+++ b/src/main/java/com/example/domain/GameSession.java
@@ -1,0 +1,44 @@
+package com.example.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "game_sessions")
+public class GameSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty difficulty;
+
+    private Integer currentMonth;
+
+    private LocalDateTime createdAt;
+
+    protected GameSession() {
+    }
+
+    public GameSession(Difficulty difficulty, Integer currentMonth, LocalDateTime createdAt) {
+        this.difficulty = difficulty;
+        this.currentMonth = currentMonth;
+        this.createdAt = createdAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Difficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public Integer getCurrentMonth() {
+        return currentMonth;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/example/domain/Indicator.java
+++ b/src/main/java/com/example/domain/Indicator.java
@@ -1,0 +1,44 @@
+package com.example.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "indicators")
+public class Indicator {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Integer value;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private GameSession session;
+
+    protected Indicator() {
+    }
+
+    public Indicator(String name, Integer value, GameSession session) {
+        this.name = name;
+        this.value = value;
+        this.session = session;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public GameSession getSession() {
+        return session;
+    }
+}

--- a/src/main/java/com/example/repository/BudgetAllocationRepository.java
+++ b/src/main/java/com/example/repository/BudgetAllocationRepository.java
@@ -1,0 +1,7 @@
+package com.example.repository;
+
+import com.example.domain.BudgetAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetAllocationRepository extends JpaRepository<BudgetAllocation, Long> {
+}

--- a/src/main/java/com/example/repository/CategoryScoreRepository.java
+++ b/src/main/java/com/example/repository/CategoryScoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.repository;
+
+import com.example.domain.CategoryScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryScoreRepository extends JpaRepository<CategoryScore, Long> {
+}

--- a/src/main/java/com/example/repository/EventLogRepository.java
+++ b/src/main/java/com/example/repository/EventLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.repository;
+
+import com.example.domain.EventLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+}

--- a/src/main/java/com/example/repository/GameSessionRepository.java
+++ b/src/main/java/com/example/repository/GameSessionRepository.java
@@ -1,0 +1,7 @@
+package com.example.repository;
+
+import com.example.domain.GameSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
+}

--- a/src/main/java/com/example/repository/IndicatorRepository.java
+++ b/src/main/java/com/example/repository/IndicatorRepository.java
@@ -1,0 +1,7 @@
+package com.example.repository;
+
+import com.example.domain.Indicator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndicatorRepository extends JpaRepository<Indicator, Long> {
+}

--- a/src/test/java/com/example/repository/RepositoryTests.java
+++ b/src/test/java/com/example/repository/RepositoryTests.java
@@ -1,0 +1,45 @@
+package com.example.repository;
+
+import com.example.domain.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class RepositoryTests {
+    @Autowired
+    private GameSessionRepository gameSessionRepository;
+
+    @Autowired
+    private IndicatorRepository indicatorRepository;
+
+    @Autowired
+    private CategoryScoreRepository categoryScoreRepository;
+
+    @Autowired
+    private BudgetAllocationRepository budgetAllocationRepository;
+
+    @Autowired
+    private EventLogRepository eventLogRepository;
+
+    @Test
+    void saveAndLoadEntities() {
+        GameSession session = new GameSession(Difficulty.EASY, 1, LocalDateTime.now());
+        session = gameSessionRepository.save(session);
+
+        indicatorRepository.save(new Indicator("Population", 1000, session));
+        categoryScoreRepository.save(new CategoryScore(CategoryType.DEFENSE, 50, session));
+        budgetAllocationRepository.save(new BudgetAllocation(CategoryType.DEFENSE, 0.2, session));
+        eventLogRepository.save(new EventLog("TEST", "test event", LocalDateTime.now(), session));
+
+        assertThat(gameSessionRepository.findById(session.getId())).isPresent();
+        assertThat(indicatorRepository.findAll()).hasSize(1);
+        assertThat(categoryScoreRepository.findAll()).hasSize(1);
+        assertThat(budgetAllocationRepository.findAll()).hasSize(1);
+        assertThat(eventLogRepository.findAll()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add initial ERD draft showing core entities
- implement JPA entity skeletons with repositories for game session, indicators, category scores, budget allocations, and event logs
- add basic repository test covering CRUD operations

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6898d03f81c4832d81a86e0caa8c0980