### PR TITLE
test: 단위(H2)/통합(Testcontainers) 테스트 분리 및 H2 예약어 충돌 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,28 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'integration'
+    }
 }
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs tests tagged with @Tag("integration").'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    shouldRunAfter tasks.test
+    useJUnitPlatform {
+        includeTags 'integration'
+    }
+    // 통합테스트는 기본적으로 'tc' 프로필로 실행
+    systemProperty 'spring.profiles.active', 'tc'
+}
+
+tasks.check { dependsOn tasks.test }

--- a/src/main/java/com/example/domain/Indicator.java
+++ b/src/main/java/com/example/domain/Indicator.java
@@ -11,6 +11,7 @@ public class Indicator {
 
     private String name;
 
+    @Column(name = "metric_value")
     private Integer value;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/test/java/com/example/StrategicCitySimulatorApplicationTests.java
+++ b/src/test/java/com/example/StrategicCitySimulatorApplicationTests.java
@@ -2,25 +2,9 @@ package com.example;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @SpringBootTest
 class StrategicCitySimulatorApplicationTests {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
-
-    @DynamicPropertySource
-    static void configureDataSource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/example/StrategicCitySimulatorIntegrationTests.java
+++ b/src/test/java/com/example/StrategicCitySimulatorIntegrationTests.java
@@ -1,0 +1,32 @@
+package com.example;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("tc")
+@Tag("integration")
+class StrategicCitySimulatorIntegrationTests {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/repository/RepositoryTests.java
+++ b/src/test/java/com/example/repository/RepositoryTests.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 class RepositoryTests {
     @Autowired
     private GameSessionRepository gameSessionRepository;

--- a/src/test/resources/application-tc.yml
+++ b/src/test/resources/application-tc.yml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+  datasource:
+    # 실주소/계정은 테스트에서 Testcontainers로 동적 주입(DynamicPropertySource)
+    driverClassName: org.postgresql.Driver
+    username: test
+    password: test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password:


### PR DESCRIPTION
  - 개요: 단위 테스트는 H2로 빠르게, 통합 테스트는 Testcontainers(PostgreSQL)로 
선택 실행하도록 분리. H2에서 value 예약어 충돌로 인한 DDL 문제 해결.
  - 변경사항:
    - build.gradle: H2 test 의존성 추가, `integrationTest` 태스크 추가, `test`에
서 integration 태그 제외
    - 테스트 리소스: `src/test/resources/application.yml`, `application-tc.yml` 
추가
      - `StrategicCitySimulatorApplicationTests`: 단순 컨텍스트 로드(@SpringBoot
Test)
      - `StrategicCitySimulatorIntegrationTests`: @Tag("integration") + @ActiveP
rofiles("tc") + Testcontainers
      - `RepositoryTests`: @DataJpaTest에 ddl-auto=create-drop 지정
    - 도메인: `Indicator.value` → `metric_value`로 컬럼명 변경(@Column)
  - 검증:
    - 단위 테스트: `./gradlew test` 통과
    - 통합 테스트: `./gradlew integrationTest` (Docker/네트워크 필요)
  - 비고: `.vscode/`는 커밋 제외

로컬에서 동일하게 검증하려면

- 단위 테스트: `./gradlew test`
- 통합 테스트: `./gradlew integrationTest` (Docker 실행 가능 환경 필요)