### PR TITLE
chore: add issue templates T2–T9

### DIFF
--- a/.github/ISSUE_TEMPLATE/T2-1.yml
+++ b/.github/ISSUE_TEMPLATE/T2-1.yml
@@ -1,0 +1,26 @@
+name: Task - T2-1
+description: 지표 업데이트 포뮬러 모듈
+title: "[T2-1] 지표 업데이트 포뮬러 모듈"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `IndicatorEngine` 인터페이스 + 기본 구현(투자효율/자연변화/상호작용 파라미터 주입).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - 서비스/유닛 테스트.
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 단위 테스트로 공식 검증(예상값 ±오차)
+

--- a/.github/ISSUE_TEMPLATE/T2-2.yml
+++ b/.github/ISSUE_TEMPLATE/T2-2.yml
@@ -1,0 +1,26 @@
+name: Task - T2-2
+description: 상호작용 매트릭스 모듈
+title: "[T2-2] 상호작용 매트릭스 모듈"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        카테고리 간 영향도 행렬 로딩( YAML/JSON ).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 샘플 매트릭스 로딩 및 적용 테스트
+

--- a/.github/ISSUE_TEMPLATE/T2-3.yml
+++ b/.github/ISSUE_TEMPLATE/T2-3.yml
@@ -1,0 +1,26 @@
+name: Task - T2-3
+description: 이벤트 처리기(확률/조건/효과)
+title: "[T2-3] 이벤트 처리기(확률/조건/효과)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `EventEngine`—확률 계산, 조건 평가, 효과 적용.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 5개 샘플 이벤트에 대한 시뮬레이션 테스트
+

--- a/.github/ISSUE_TEMPLATE/T2-4.yml
+++ b/.github/ISSUE_TEMPLATE/T2-4.yml
@@ -1,0 +1,26 @@
+name: Task - T2-4
+description: 월간 턴 실행 유스케이스
+title: "[T2-4] 월간 턴 실행 유스케이스"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `SimulateMonthUseCase(sessionId, allocations)`; 엔진 호출→결과 저장.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 인메모리/pg 환경에서 월 턴 진행 통합테스트
+

--- a/.github/ISSUE_TEMPLATE/T3-1.yml
+++ b/.github/ISSUE_TEMPLATE/T3-1.yml
@@ -1,0 +1,27 @@
+name: Task - T3-1
+description: 세션 시작 API
+title: "[T3-1] 세션 시작 API"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `POST /api/v1/sessions` (난이도/프리셋).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 201 Created & 초기 지표 반환
+        - label: OpenAPI 명세 포함
+

--- a/.github/ISSUE_TEMPLATE/T3-2.yml
+++ b/.github/ISSUE_TEMPLATE/T3-2.yml
@@ -1,0 +1,26 @@
+name: Task - T3-2
+description: 예산 배분/시뮬레이트 API
+title: "[T3-2] 예산 배분/시뮬레이트 API"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `POST /api/v1/sessions/{id}/simulate` (월 예산 배분 입력).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 결과에 지표 변화/이벤트/카테고리/종합지수 포함
+

--- a/.github/ISSUE_TEMPLATE/T3-3.yml
+++ b/.github/ISSUE_TEMPLATE/T3-3.yml
@@ -1,0 +1,26 @@
+name: Task - T3-3
+description: 리포트 조회 API
+title: "[T3-3] 리포트 조회 API"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `GET /api/v1/sessions/{id}/reports?year=&month=`.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 월간 요약/누적 통계 반환
+

--- a/.github/ISSUE_TEMPLATE/T3-4.yml
+++ b/.github/ISSUE_TEMPLATE/T3-4.yml
@@ -1,0 +1,27 @@
+name: Task - T3-4
+description: OpenAPI 문서화 & 스니펫 테스트
+title: "[T3-4] OpenAPI 문서화 & 스니펫 테스트"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        springdoc-openapi UI, REST Docs 또는 springdoc Tests.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: '/swagger-ui' 노출
+        - label: 기본 시나리오 스니펫 생성
+

--- a/.github/ISSUE_TEMPLATE/T4-1.yml
+++ b/.github/ISSUE_TEMPLATE/T4-1.yml
@@ -1,0 +1,27 @@
+name: Task - T4-1
+description: 미니 대시보드(정적/SPA 한 페이지)
+title: "[T4-1] 미니 대시보드(정적/SPA 한 페이지)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        Vite + React 최소 템플릿, 예산 슬라이더, 결과 테이블.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 로컬에서 백엔드 연동
+        - label: 한 턴 시뮬레이트 가능
+

--- a/.github/ISSUE_TEMPLATE/T4-2.yml
+++ b/.github/ISSUE_TEMPLATE/T4-2.yml
@@ -1,0 +1,26 @@
+name: Task - T4-2
+description: 월간 보고서 표/간단 차트
+title: "[T4-2] 월간 보고서 표/간단 차트"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        변화 화살표/미니 차트(Chart.js).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 3개 지표 이상 그래프 표시
+

--- a/.github/ISSUE_TEMPLATE/T5-1.yml
+++ b/.github/ISSUE_TEMPLATE/T5-1.yml
@@ -1,0 +1,27 @@
+name: Task - T5-1
+description: 단위/통합 테스트 기본 세트
+title: "[T5-1] 단위/통합 테스트 기본 세트"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        JUnit5/AssertJ/MockMvc, Testcontainers(Postgres).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 라인 커버리지 60%+
+        - label: 핵심 유스케이스 통합 테스트
+

--- a/.github/ISSUE_TEMPLATE/T5-2.yml
+++ b/.github/ISSUE_TEMPLATE/T5-2.yml
@@ -1,0 +1,26 @@
+name: Task - T5-2
+description: 시뮬레이션 회귀 테스트 스냅샷
+title: "[T5-2] 시뮬레이션 회귀 테스트 스냅샷"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        고정 시드로 12개월 실행, 결과 스냅샷 비교.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 변경 시 결과 차이 탐지 알림
+

--- a/.github/ISSUE_TEMPLATE/T5-3.yml
+++ b/.github/ISSUE_TEMPLATE/T5-3.yml
@@ -1,0 +1,26 @@
+name: Task - T5-3
+description: 부하 테스트(가벼운)
+title: "[T5-3] 부하 테스트(가벼운)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        k6 or JMeter로 간단 RPS, 95p 지연 < 200ms(시뮬레이트).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 리포트 아카이브
+

--- a/.github/ISSUE_TEMPLATE/T6-1.yml
+++ b/.github/ISSUE_TEMPLATE/T6-1.yml
@@ -1,0 +1,26 @@
+name: Task - T6-1
+description: GCP 프로젝트/레지스트리/권한
+title: "[T6-1] GCP 프로젝트/레지스트리/권한"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        Artifact Registry 생성, 서비스 계정/워크로드 아이덴티티.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: '`gcloud`로 로그인 없이 GA에서 푸시 성공'
+

--- a/.github/ISSUE_TEMPLATE/T6-2.yml
+++ b/.github/ISSUE_TEMPLATE/T6-2.yml
@@ -1,0 +1,26 @@
+name: Task - T6-2
+description: Cloud SQL(Postgres) 준비
+title: "[T6-2] Cloud SQL(Postgres) 준비"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        인스턴스/DB/사용자 생성, VPC/프록시 방식 결정(Cloud Run 연결).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 로컬→Cloud SQL Proxy로 연결 테스트
+

--- a/.github/ISSUE_TEMPLATE/T6-3.yml
+++ b/.github/ISSUE_TEMPLATE/T6-3.yml
@@ -1,0 +1,26 @@
+name: Task - T6-3
+description: Secret Manager 통합
+title: "[T6-3] Secret Manager 통합"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        DB 비번, JWT 시크릿 등 저장; SB에서 Secret Manager 연동.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 프로퍼티 주입 성공 및 로깅 마스킹
+

--- a/.github/ISSUE_TEMPLATE/T6-4.yml
+++ b/.github/ISSUE_TEMPLATE/T6-4.yml
@@ -1,0 +1,27 @@
+name: Task - T6-4
+description: Cloud Run 배포 파이프라인
+title: "[T6-4] Cloud Run 배포 파이프라인"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        GA CD 워크플로우(main 머지 시 배포), 리비전 자동 롤백 전략.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: '/actuator/health' 정상
+        - label: 트래픽 스플릿 배포 확인
+

--- a/.github/ISSUE_TEMPLATE/T6-5.yml
+++ b/.github/ISSUE_TEMPLATE/T6-5.yml
@@ -1,0 +1,27 @@
+name: Task - T6-5
+description: 로깅/모니터링
+title: "[T6-5] 로깅/모니터링"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        Cloud Logging/Cloud Monitoring 연동, 구조화 로그(JSON).
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 대시보드 1개
+        - label: 경보(에러율/레이터시) 2개
+

--- a/.github/ISSUE_TEMPLATE/T7-1.yml
+++ b/.github/ISSUE_TEMPLATE/T7-1.yml
@@ -1,0 +1,26 @@
+name: Task - T7-1
+description: 구성 유효성 검증
+title: "[T7-1] 구성 유효성 검증"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        `@ConfigurationProperties` + validation.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 잘못된 설정으로 기동 실패 시 명확한 에러
+

--- a/.github/ISSUE_TEMPLATE/T7-2.yml
+++ b/.github/ISSUE_TEMPLATE/T7-2.yml
@@ -1,0 +1,26 @@
+name: Task - T7-2
+description: 프로파일별 외부화 구성
+title: "[T7-2] 프로파일별 외부화 구성"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        prod는 Secret Manager, dev/local은 `.env`/yaml.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 세 가지 프로필 모두 기동 OK
+

--- a/.github/ISSUE_TEMPLATE/T7-3.yml
+++ b/.github/ISSUE_TEMPLATE/T7-3.yml
@@ -1,0 +1,26 @@
+name: Task - T7-3
+description: 감사/이벤트 로그
+title: "[T7-3] 감사/이벤트 로그"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        주요 액션 감사 로그, 이벤트 결과 `EventLog` 저장.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 월 턴 실행 시 로그/DB 기록 확인
+

--- a/.github/ISSUE_TEMPLATE/T8-1.yml
+++ b/.github/ISSUE_TEMPLATE/T8-1.yml
@@ -1,0 +1,26 @@
+name: Task - T8-1
+description: 운영/개발 README
+title: "[T8-1] 운영/개발 README"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        로컬 실행, 테스트, 도커 빌드, GCP 배포 가이드.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 신입이 따라 해서 30분 내 로컬 실행 성공
+

--- a/.github/ISSUE_TEMPLATE/T8-2.yml
+++ b/.github/ISSUE_TEMPLATE/T8-2.yml
@@ -1,0 +1,26 @@
+name: Task - T8-2
+description: API 사용 가이드
+title: "[T8-2] API 사용 가이드"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        cURL/HTTPie 샘플, 응답 예시, 에러 코드 표.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 최소 5개 시나리오 샘플 포함
+

--- a/.github/ISSUE_TEMPLATE/T8-3.yml
+++ b/.github/ISSUE_TEMPLATE/T8-3.yml
@@ -1,0 +1,26 @@
+name: Task - T8-3
+description: 설정/비밀키 관리 정책
+title: "[T8-3] 설정/비밀키 관리 정책"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        환경변수/시크릿, 회전 절차.
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 📦 산출물
+      value: |
+        - (해당 없음)
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: ✅ Definition of Done
+      options:
+        - label: 문서 승인
+

--- a/.github/ISSUE_TEMPLATE/T9-1.yml
+++ b/.github/ISSUE_TEMPLATE/T9-1.yml
@@ -1,0 +1,12 @@
+name: Task - T9-1
+description: 하이브리드 저장(스냅샷 압축/리플레이)
+title: "[T9-1] 하이브리드 저장(스냅샷 압축/리플레이)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        (세부 내용 미정 — tasklist.md 기준 초기 템플릿)
+

--- a/.github/ISSUE_TEMPLATE/T9-2.yml
+++ b/.github/ISSUE_TEMPLATE/T9-2.yml
@@ -1,0 +1,12 @@
+name: Task - T9-2
+description: 난이도 프리셋 편집 UI
+title: "[T9-2] 난이도 프리셋 편집 UI"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        (세부 내용 미정 — tasklist.md 기준 초기 템플릿)
+

--- a/.github/ISSUE_TEMPLATE/T9-3.yml
+++ b/.github/ISSUE_TEMPLATE/T9-3.yml
@@ -1,0 +1,12 @@
+name: Task - T9-3
+description: AI 정책 어드바이저(권고 예산 비율)
+title: "[T9-3] AI 정책 어드바이저(권고 예산 비율)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        (세부 내용 미정 — tasklist.md 기준 초기 템플릿)
+

--- a/.github/ISSUE_TEMPLATE/T9-4.yml
+++ b/.github/ISSUE_TEMPLATE/T9-4.yml
@@ -1,0 +1,12 @@
+name: Task - T9-4
+description: 이벤트 모더레이션 파일 외부화(Admin UI)
+title: "[T9-4] 이벤트 모더레이션 파일 외부화(Admin UI)"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        (세부 내용 미정 — tasklist.md 기준 초기 템플릿)
+

--- a/.github/ISSUE_TEMPLATE/T9-5.yml
+++ b/.github/ISSUE_TEMPLATE/T9-5.yml
@@ -1,0 +1,12 @@
+name: Task - T9-5
+description: 멀티 세션 동시 실행 최적화
+title: "[T9-5] 멀티 세션 동시 실행 최적화"
+labels: ["task"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Task 개요
+        (세부 내용 미정 — tasklist.md 기준 초기 템플릿)
+


### PR DESCRIPTION
- Adds GitHub issue templates for T2-1 through T9-5
- Mirrors tasklist.md: 내용/산출물/DOD
- T9-* are minimal placeholders due to unspecified details

Also noticed a stray T2-1 note inside T1-3 template; can clean in a follow-up.