### PR TITLE
feat: 프로필별 구성 파일 분리

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://dev-db:5432/strategic_city_simulator
+    username: dev
+    password: devpass
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  security:
+    user:
+      name: dev
+      password: devpass
+logging:
+  level:
+    root: INFO
+server:
+  port: 8080

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,5 +9,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  security:
+    user:
+      name: local
+      password: localpass
+logging:
+  level:
+    root: DEBUG
 server:
   port: 8080

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  security:
+    user:
+      name: ${APP_USER}
+      password: ${APP_PASSWORD}
+logging:
+  level:
+    root: WARN
+server:
+  port: 8080

--- a/src/test/java/com/example/LocalProfileTests.java
+++ b/src/test/java/com/example/LocalProfileTests.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(properties = {
+    "spring.datasource.url=jdbc:h2:mem:localtest;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driverClassName=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@ActiveProfiles("local")
+class LocalProfileTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/ProdProfileTests.java
+++ b/src/test/java/com/example/ProdProfileTests.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(properties = {
+    "spring.datasource.url=jdbc:h2:mem:prodtest;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driverClassName=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.security.user.name=test",
+    "spring.security.user.password=test"
+})
+@ActiveProfiles("prod")
+class ProdProfileTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- 로컬/개발/프로덕션 환경별 YAML 구성 추가
- 프로필 전환 테스트로 로컬·프로덕션 컨텍스트 로드 검증

## Testing
- `./gradlew test` *(실패: Could not GET ... Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689962dd4d40832d800621e753afb640