### PR TITLE
docs: add Figma wireframe SVGs and guide

### DIFF
--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -1,0 +1,46 @@
+# Figma 임포트 가이드
+
+이 폴더에는 Figma에서 즉시 가져와 참고/트레이싱할 수 있는 SVG 와이어프레임이 포함되어 있습니다. 각 SVG는 프레임 단위(1440×1024 데스크톱, 390×844 모바일)로 구성되었습니다.
+
+## 파일 목록
+- `figma/Main_Dashboard.svg`: 메인 대시보드(지표 요약 + 예산 슬라이더 + 턴 진행)
+- `figma/Monthly_Report_Modal.svg`: 월간 보고서 모달
+- `figma/Trends_Timeline.svg`: 지수 추이 그래프 + 이벤트 타임라인
+- `figma/New_Game_Dialog.svg`: 새 게임 시작(난이도/초기상태)
+- `figma/Event_Log_Drawer.svg`: 이벤트 로그 드로어
+- `figma/Mobile_Layout.svg`: 모바일 레이아웃(상단 카드 + 하단 슬라이더)
+
+## Figma로 가져오기
+1. Figma에서 새 파일을 만들고 페이지를 `Wireframes`로 생성합니다.
+2. 메뉴 `File > Place image` 또는 드래그&드롭으로 각 SVG를 캔버스에 올립니다.
+3. 필요시 `Right click > Ungroup`로 그룹 해제 후, `Outline stroke`를 적용해 편집성을 높입니다.
+4. Auto Layout 전환 팁:
+   - 카테고리 카드 묶음: `Shift`로 카드들을 선택 → `Auto layout (Shift+A)` → 방향 `Vertical`, `Spacing 12`.
+   - 예산 슬라이더 리스트: 리스트 컨테이너에 Auto layout → `Vertical`, `Spacing 8`, 내부 각 항목은 `Horizontal`, `Spacing 12`.
+
+## 디자인 토큰 제안 (Figma Styles/Variables로 등록)
+- Colors
+  - `Neutral/100`: #111111
+  - `Neutral/70`: #666666
+  - `Neutral/30`: #CCCCCC
+  - `Accent/Blue`: #2F80ED (강조, 링크)
+  - `Accent/Green`: #27AE60 (상승)
+  - `Accent/Red`: #EB5757 (하락)
+- Typography
+  - Display: Inter 24/32 Bold
+  - H2: Inter 18/24 Semibold
+  - Body: Inter 14/20 Regular
+  - Caption: Inter 12/16 Regular
+- Spacing (8pt 그리드)
+  - XS 4 / S 8 / M 12 / L 16 / XL 24 / XXL 32
+
+## 컴포넌트 브레이크다운
+- `Card/Category`: 타이틀, 값, 변화 배지, 스파크라인
+- `List/BudgetItem`: 라벨, 퍼센트, 슬라이더, 금액, 힌트
+- `Banner/TopBar`: 도시명, 턴, 예산, 난이도, 액션(저장/설정)
+- `Modal/MonthlyReport`: 헤더, 카테고리 변화 표, 이벤트 리스트, 재정 요약, CTA
+- `Drawer/EventLog`: 월/이벤트/효과 항목 리스트
+
+## 다음 단계
+- 필요하시면 제가 컴포넌트화(Variants/Auto Layout/Constraints 세팅)된 Figma 파일 구조를 제안하거나, 실제 Figma 파일로 업로드해 드릴 수 있습니다. (네트워크 접근 허용 또는 공유 링크 제공 필요)
+

--- a/docs/wireframes/figma/Event_Log_Drawer.svg
+++ b/docs/wireframes/figma/Event_Log_Drawer.svg
@@ -1,0 +1,19 @@
+<svg width="1440" height="1024" viewBox="0 0 1440 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1024" fill="#FFFFFF"/>
+  <!-- Drawer background -->
+  <rect x="960" y="0" width="480" height="1024" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="992" y="48" font-family="Inter, Arial" font-size="18" fill="#111">이벤트 로그 (최근 6개월)</text>
+
+  <!-- Items -->
+  <rect x="976" y="72" width="448" height="64" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="992" y="108" font-family="Inter, Arial" font-size="13" fill="#111">3월: 무역 협정 체결 · +경제5 +외교3</text>
+  <rect x="976" y="144" width="448" height="64" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="992" y="180" font-family="Inter, Arial" font-size="13" fill="#111">2월: 태풍 피해 회피 · (환경 ≥ 60)</text>
+  <rect x="976" y="216" width="448" height="64" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="992" y="252" font-family="Inter, Arial" font-size="13" fill="#111">1월: 산업 투자 확대 · +경제3 -환경1</text>
+
+  <!-- Close button -->
+  <rect x="1376" y="24" width="40" height="40" rx="8" fill="#EDEDED" stroke="#CCCCCC"/>
+  <text x="1390" y="50" font-family="Inter, Arial" font-size="14" fill="#111">×</text>
+</svg>
+

--- a/docs/wireframes/figma/Main_Dashboard.svg
+++ b/docs/wireframes/figma/Main_Dashboard.svg
@@ -1,0 +1,84 @@
+<svg width="1440" height="1024" viewBox="0 0 1440 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1024" fill="#FFFFFF"/>
+  <!-- Top Bar -->
+  <rect x="32" y="24" width="1376" height="56" rx="8" fill="#F5F5F5" stroke="#DDDDDD"/>
+  <text x="48" y="58" font-family="Inter, Arial" font-size="18" fill="#111">도시명 · 턴 3 (2025-03) · 예산 10억 · Normal</text>
+  <rect x="1250" y="36" width="72" height="32" rx="6" fill="#EDEDED" stroke="#CCCCCC"/>
+  <text x="1273" y="57" font-family="Inter, Arial" font-size="12" fill="#111">저장</text>
+  <rect x="1330" y="36" width="72" height="32" rx="6" fill="#EDEDED" stroke="#CCCCCC"/>
+  <text x="1353" y="57" font-family="Inter, Arial" font-size="12" fill="#111">설정</text>
+
+  <!-- Left Column: Summary and Details -->
+  <rect x="32" y="96" width="688" height="832" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <!-- City Index Card -->
+  <rect x="48" y="112" width="656" height="160" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="64" y="146" font-family="Inter, Arial" font-size="16" fill="#111">종합 도시 지수: 68 ▲ +2</text>
+  <!-- Progress bar -->
+  <rect x="64" y="168" width="624" height="16" rx="8" fill="#EEE"/>
+  <rect x="64" y="168" width="480" height="16" rx="8" fill="#BDBDBD"/>
+  <!-- Details toggle and items -->
+  <text x="64" y="214" font-family="Inter, Arial" font-size="14" fill="#111">세부 지표</text>
+  <text x="64" y="242" font-family="Inter, Arial" font-size="13" fill="#666">> 경제 · GDP 1000 ▲ +1.8% · 실업률 6.0 ▼ -0.3</text>
+  <text x="64" y="268" font-family="Inter, Arial" font-size="13" fill="#666">> 정치 안정도 55 ▼ -1</text>
+
+  <!-- Right Column: Category Cards -->
+  <rect x="736" y="96" width="672" height="480" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="752" y="126" font-family="Inter, Arial" font-size="16" fill="#111">카테고리</text>
+  <!-- Six cards grid 3x2 -->
+  <rect x="752" y="144" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="768" y="170" font-family="Inter, Arial" font-size="14" fill="#111">경제: 72 ▲ +3</text>
+  <rect x="1048" y="144" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="1064" y="170" font-family="Inter, Arial" font-size="14" fill="#111">정치: 58 ▼ -1</text>
+  <rect x="752" y="300" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="768" y="326" font-family="Inter, Arial" font-size="14" fill="#111">국방: 51 ▬ ±0</text>
+  <rect x="1048" y="300" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="1064" y="326" font-family="Inter, Arial" font-size="14" fill="#111">외교: 64 ▲ +1</text>
+  <rect x="752" y="456" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="768" y="482" font-family="Inter, Arial" font-size="14" fill="#111">문화: 55 ▲ +2</text>
+  <rect x="1048" y="456" width="320" height="140" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="1064" y="482" font-family="Inter, Arial" font-size="14" fill="#111">환경: 62 ▼ -2</text>
+
+  <!-- Budget Allocation Panel -->
+  <rect x="736" y="592" width="672" height="336" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="752" y="620" font-family="Inter, Arial" font-size="16" fill="#111">월간 예산 배분</text>
+  <text x="752" y="644" font-family="Inter, Arial" font-size="12" fill="#666">세수 10억 · 외부 지원 0.5억 · 잔여금 0.2억</text>
+  <!-- Budget Items -->
+  <g>
+    <text x="752" y="676" font-family="Inter, Arial" font-size="13" fill="#111">국방 15% (1.5억)</text>
+    <rect x="900" y="664" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="664" width="210" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <g>
+    <text x="752" y="704" font-family="Inter, Arial" font-size="13" fill="#111">외교 10% (1.0억)</text>
+    <rect x="900" y="692" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="692" width="140" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <g>
+    <text x="752" y="732" font-family="Inter, Arial" font-size="13" fill="#111">경제 30% (3.0억)</text>
+    <rect x="900" y="720" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="720" width="300" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <g>
+    <text x="752" y="760" font-family="Inter, Arial" font-size="13" fill="#111">정치 15% (1.5억)</text>
+    <rect x="900" y="748" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="748" width="210" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <g>
+    <text x="752" y="788" font-family="Inter, Arial" font-size="13" fill="#111">문화 15% (1.5억)</text>
+    <rect x="900" y="776" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="776" width="210" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <g>
+    <text x="752" y="816" font-family="Inter, Arial" font-size="13" fill="#111">환경 15% (1.5억)</text>
+    <rect x="900" y="804" width="420" height="12" rx="6" fill="#EEE"/>
+    <rect x="900" y="804" width="210" height="12" rx="6" fill="#BDBDBD"/>
+  </g>
+  <text x="752" y="848" font-family="Inter, Arial" font-size="12" fill="#666">합계 100% · [자동 균형] [초기화]</text>
+
+  <!-- Event log and CTA -->
+  <text x="48" y="952" font-family="Inter, Arial" font-size="12" fill="#666">이벤트 로그 ▸ 최근: 무역 협정 체결(외교 +3, 경제 +5)</text>
+  <rect x="1200" y="936" width="208" height="48" rx="8" fill="#2F80ED"/>
+  <text x="1238" y="965" font-family="Inter, Arial" font-size="16" fill="#FFF">턴 진행 ▶︎</text>
+  <text x="992" y="965" font-family="Inter, Arial" font-size="12" fill="#666">예상 변화: 종합 +1~+3 · 리스크: 부채 70%</text>
+</svg>
+

--- a/docs/wireframes/figma/Mobile_Layout.svg
+++ b/docs/wireframes/figma/Mobile_Layout.svg
@@ -1,0 +1,38 @@
+<svg width="390" height="844" viewBox="0 0 390 844" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="390" height="844" fill="#FFFFFF"/>
+  <!-- Header -->
+  <text x="16" y="32" font-family="Inter, Arial" font-size="16" fill="#111">도시 지표</text>
+  <!-- Summary Card -->
+  <rect x="16" y="48" width="358" height="120" rx="10" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="32" y="80" font-family="Inter, Arial" font-size="14" fill="#111">종합 도시 지수: 68 ▲ +2</text>
+  <rect x="32" y="92" width="322" height="12" rx="6" fill="#EEE"/>
+  <rect x="32" y="92" width="240" height="12" rx="6" fill="#BDBDBD"/>
+
+  <!-- Category horizontal scroll (represented as stacked cards) -->
+  <rect x="16" y="180" width="358" height="180" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="32" y="204" font-family="Inter, Arial" font-size="14" fill="#111">카테고리</text>
+  <rect x="32" y="220" width="300" height="56" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="48" y="252" font-family="Inter, Arial" font-size="12" fill="#111">경제: 72 ▲ +3</text>
+  <rect x="32" y="284" width="300" height="56" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="48" y="316" font-family="Inter, Arial" font-size="12" fill="#111">정치: 58 ▼ -1</text>
+
+  <!-- Budget (Accordion-like) -->
+  <rect x="16" y="372" width="358" height="300" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="32" y="396" font-family="Inter, Arial" font-size="14" fill="#111">예산 배분</text>
+  <text x="32" y="416" font-family="Inter, Arial" font-size="11" fill="#666">세수 10억 · 외부 0.5억 · 잔여 0.2억</text>
+  <text x="32" y="444" font-family="Inter, Arial" font-size="12" fill="#111">경제 30% (3.0억)</text>
+  <rect x="32" y="452" width="322" height="10" rx="5" fill="#EEE"/>
+  <rect x="32" y="452" width="200" height="10" rx="5" fill="#BDBDBD"/>
+  <text x="32" y="476" font-family="Inter, Arial" font-size="12" fill="#111">국방 15% (1.5억)</text>
+  <rect x="32" y="484" width="322" height="10" rx="5" fill="#EEE"/>
+  <rect x="32" y="484" width="120" height="10" rx="5" fill="#BDBDBD"/>
+  <text x="32" y="508" font-family="Inter, Arial" font-size="12" fill="#111">외교 10% (1.0억)</text>
+  <rect x="32" y="516" width="322" height="10" rx="5" fill="#EEE"/>
+  <rect x="32" y="516" width="80" height="10" rx="5" fill="#BDBDBD"/>
+  <text x="32" y="540" font-family="Inter, Arial" font-size="11" fill="#666">합계 100% · 자동 균형 · 초기화</text>
+
+  <!-- Fixed CTA -->
+  <rect x="16" y="692" width="358" height="48" rx="8" fill="#2F80ED"/>
+  <text x="150" y="722" font-family="Inter, Arial" font-size="16" fill="#FFF">턴 진행 ▶︎</text>
+</svg>
+

--- a/docs/wireframes/figma/Monthly_Report_Modal.svg
+++ b/docs/wireframes/figma/Monthly_Report_Modal.svg
@@ -1,0 +1,42 @@
+<svg width="1440" height="1024" viewBox="0 0 1440 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1024" fill="#F7F7F7"/>
+  <!-- Modal backdrop -->
+  <rect width="1440" height="1024" fill="#000" fill-opacity="0.2"/>
+  <!-- Modal -->
+  <rect x="240" y="128" width="960" height="768" rx="12" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="272" y="170" font-family="Inter, Arial" font-size="20" fill="#111">월간 보고서 - 2025년 3월</text>
+
+  <!-- Summary Row -->
+  <rect x="272" y="192" width="896" height="64" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="288" y="230" font-family="Inter, Arial" font-size="14" fill="#111">종합 지수: 68 → 71 ▲ +3</text>
+
+  <!-- Category Changes -->
+  <text x="272" y="276" font-family="Inter, Arial" font-size="16" fill="#111">카테고리 변화</text>
+  <rect x="272" y="288" width="896" height="160" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="288" y="320" font-family="Inter, Arial" font-size="13" fill="#111">경제: 72 → 75 ▲ +3</text>
+  <text x="520" y="320" font-family="Inter, Arial" font-size="13" fill="#111">정치: 58 → 56 ▼ -2</text>
+  <text x="288" y="348" font-family="Inter, Arial" font-size="13" fill="#111">국방: 51 → 52 ▲ +1</text>
+  <text x="520" y="348" font-family="Inter, Arial" font-size="13" fill="#111">외교: 64 → 66 ▲ +2</text>
+  <text x="288" y="376" font-family="Inter, Arial" font-size="13" fill="#111">문화: 55 → 57 ▲ +2</text>
+  <text x="520" y="376" font-family="Inter, Arial" font-size="13" fill="#111">환경: 62 → 60 ▼ -2</text>
+
+  <!-- Events -->
+  <text x="272" y="472" font-family="Inter, Arial" font-size="16" fill="#111">이벤트</text>
+  <rect x="272" y="484" width="896" height="128" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="288" y="516" font-family="Inter, Arial" font-size="13" fill="#111">[✓] 무역 협정 체결: 경제 +5, 국제 신뢰도 +3</text>
+  <text x="288" y="544" font-family="Inter, Arial" font-size="13" fill="#666">[ ] 태풍 피해 (조건 미충족)</text>
+
+  <!-- Highlights and Finance -->
+  <text x="272" y="652" font-family="Inter, Arial" font-size="16" fill="#111">하이라이트 · 재정</text>
+  <rect x="272" y="664" width="560" height="96" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="288" y="696" font-family="Inter, Arial" font-size="13" fill="#111">GDP +1.8% · 실업률 -0.3% · 안정도 -2 · 대기질 -2</text>
+  <rect x="848" y="664" width="320" height="96" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="864" y="696" font-family="Inter, Arial" font-size="13" fill="#111">세수 +2% · 지출 9.0억 · 잔여 1.0억 · 부채 0</text>
+
+  <!-- Actions -->
+  <rect x="1040" y="848" width="112" height="40" rx="8" fill="#EDEDED" stroke="#CCCCCC"/>
+  <text x="1072" y="873" font-family="Inter, Arial" font-size="14" fill="#111">세부 보고서</text>
+  <rect x="1156" y="848" width="112" height="40" rx="8" fill="#2F80ED"/>
+  <text x="1188" y="873" font-family="Inter, Arial" font-size="14" fill="#FFF">다음으로</text>
+</svg>
+

--- a/docs/wireframes/figma/New_Game_Dialog.svg
+++ b/docs/wireframes/figma/New_Game_Dialog.svg
@@ -1,0 +1,20 @@
+<svg width="1440" height="1024" viewBox="0 0 1440 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1024" fill="#F7F7F7"/>
+  <rect width="1440" height="1024" fill="#000" fill-opacity="0.2"/>
+  <!-- Dialog -->
+  <rect x="456" y="240" width="528" height="448" rx="12" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <text x="488" y="280" font-family="Inter, Arial" font-size="20" fill="#111">새 게임</text>
+  <text x="488" y="320" font-family="Inter, Arial" font-size="14" fill="#111">난이도</text>
+  <rect x="488" y="332" width="464" height="40" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="504" y="358" font-family="Inter, Arial" font-size="13" fill="#666">( ) Easy   (•) Normal   ( ) Hard</text>
+  <text x="488" y="396" font-family="Inter, Arial" font-size="14" fill="#111">초기 상태</text>
+  <rect x="488" y="408" width="464" height="40" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="504" y="434" font-family="Inter, Arial" font-size="13" fill="#666">자동 ▼</text>
+  <rect x="488" y="472" width="464" height="72" rx="8" fill="#FFFFFF" stroke="#E6E6E6"/>
+  <text x="504" y="516" font-family="Inter, Arial" font-size="12" fill="#666">설명: 세수/효율/이벤트 빈도가 난이도에 따라 달라집니다.</text>
+  <rect x="760" y="608" width="88" height="40" rx="8" fill="#EDEDED" stroke="#CCCCCC"/>
+  <text x="786" y="633" font-family="Inter, Arial" font-size="14" fill="#111">취소</text>
+  <rect x="864" y="608" width="88" height="40" rx="8" fill="#2F80ED"/>
+  <text x="882" y="633" font-family="Inter, Arial" font-size="14" fill="#FFF">시작</text>
+</svg>
+

--- a/docs/wireframes/figma/Trends_Timeline.svg
+++ b/docs/wireframes/figma/Trends_Timeline.svg
@@ -1,0 +1,38 @@
+<svg width="1440" height="1024" viewBox="0 0 1440 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1024" fill="#FFFFFF"/>
+  <!-- Header -->
+  <text x="32" y="56" font-family="Inter, Arial" font-size="20" fill="#111">지표 추이 · 최근 12개월</text>
+  <rect x="32" y="72" width="320" height="36" rx="6" fill="#F5F5F5" stroke="#DDDDDD"/>
+  <text x="48" y="96" font-family="Inter, Arial" font-size="13" fill="#666">지수: 종합 · 경제 · 정치 · 국방 · 외교 · 문화 · 환경</text>
+
+  <!-- Chart area -->
+  <rect x="32" y="128" width="1376" height="560" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <!-- Simple sparkline-like path (placeholder) -->
+  <polyline points="64,640 208,600 352,580 496,520 640,540 784,500 928,460 1072,480 1216,420 1360,400" fill="none" stroke="#BDBDBD" stroke-width="3"/>
+  <!-- Y-axis labels -->
+  <text x="40" y="160" font-family="Inter, Arial" font-size="12" fill="#666">80</text>
+  <text x="40" y="240" font-family="Inter, Arial" font-size="12" fill="#666">70</text>
+  <text x="40" y="320" font-family="Inter, Arial" font-size="12" fill="#666">60</text>
+  <text x="40" y="400" font-family="Inter, Arial" font-size="12" fill="#666">50</text>
+  <line x1="64" y1="168" x2="1376" y2="168" stroke="#EEE"/>
+  <line x1="64" y1="248" x2="1376" y2="248" stroke="#EEE"/>
+  <line x1="64" y1="328" x2="1376" y2="328" stroke="#EEE"/>
+  <line x1="64" y1="408" x2="1376" y2="408" stroke="#EEE"/>
+
+  <!-- X-axis months -->
+  <text x="160" y="712" font-family="Inter, Arial" font-size="12" fill="#666">10월</text>
+  <text x="304" y="712" font-family="Inter, Arial" font-size="12" fill="#666">11월</text>
+  <text x="448" y="712" font-family="Inter, Arial" font-size="12" fill="#666">12월</text>
+  <text x="592" y="712" font-family="Inter, Arial" font-size="12" fill="#666">1월</text>
+  <text x="736" y="712" font-family="Inter, Arial" font-size="12" fill="#666">2월</text>
+  <text x="880" y="712" font-family="Inter, Arial" font-size="12" fill="#666">3월</text>
+
+  <!-- Event timeline -->
+  <text x="32" y="780" font-family="Inter, Arial" font-size="16" fill="#111">이벤트 타임라인</text>
+  <rect x="32" y="792" width="1376" height="160" rx="10" fill="#FFFFFF" stroke="#DDDDDD"/>
+  <rect x="160" y="824" width="216" height="40" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="176" y="850" font-family="Inter, Arial" font-size="12" fill="#111">11월 · 부패 스캔들 (정치 -10)</text>
+  <rect x="720" y="824" width="280" height="40" rx="8" fill="#FAFAFA" stroke="#E6E6E6"/>
+  <text x="736" y="850" font-family="Inter, Arial" font-size="12" fill="#111">3월 · 무역 협정 (경제 +5, 외교 +3)</text>
+</svg>
+


### PR DESCRIPTION
## 개요
PRD 기반으로 Figma 임포트용 SVG 와이어프레임과 사용 가이드를 추가합니다.

## 변경 내용
- docs/wireframes/README.md: 임포트 방법, Auto Layout 팁, 디자인 토큰 제안
- docs/wireframes/figma/Main_Dashboard.svg: 메인 대시보드(지표/예산/턴)
- docs/wireframes/figma/Monthly_Report_Modal.svg: 월간 보고서 모달
- docs/wireframes/figma/Trends_Timeline.svg: 지수 추이 및 이벤트 타임라인
- docs/wireframes/figma/New_Game_Dialog.svg: 새 게임 시작 다이얼로그
- docs/wireframes/figma/Event_Log_Drawer.svg: 이벤트 로그 드로어
- docs/wireframes/figma/Mobile_Layout.svg: 모바일 레이아웃

## 검증 방법
- Figma에서 로 SVG를 가져와 배치 후, Ungroup/Outline stroke로 수정 가능한 형태 확인

## 기타
- 향후 Figma 컴포넌트화(Variants/Auto Layout/Constraints) 요청 시 추가 작업 예정
