### PR TITLE
docs(issues): improve T4 issue templates with API refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/T4-1.yml
+++ b/.github/ISSUE_TEMPLATE/T4-1.yml
@@ -25,3 +25,9 @@ body:
       options:
         - label: 로컬에서 백엔드 연동
 
+  - type: markdown
+    attributes:
+      value: |
+        ## 🔗 참고
+        - PRD: `PRD_expanded.md`
+        - 와이어프레임: `docs/wireframes/figma/Main_Dashboard.svg`, `docs/wireframes/figma/Mobile_Layout.svg`

--- a/.github/ISSUE_TEMPLATE/T4-2.yml
+++ b/.github/ISSUE_TEMPLATE/T4-2.yml
@@ -25,3 +25,12 @@ body:
         - label: 시작 기능 구현
         - label: 취소 기능 구현
 
+  - type: markdown
+    attributes:
+      value: |
+        ## 🔌 연관 API
+        - `POST /api/v1/sessions` (세션 시작)
+
+        ## 🔗 참고
+        - 와이어프레임: `docs/wireframes/figma/New_Game_Dialog.svg`
+        - PRD: `PRD_expanded.md`

--- a/.github/ISSUE_TEMPLATE/T4-3.yml
+++ b/.github/ISSUE_TEMPLATE/T4-3.yml
@@ -25,3 +25,13 @@ body:
         - label: 지표 표시
         - label: 월간 예산 배분 조절 기능 완료
 
+  - type: markdown
+    attributes:
+      value: |
+        ## 🔌 연관 API
+        - `POST /api/v1/sessions/{id}/simulate` (월 예산 배분 시뮬레이트)
+        - `GET /api/v1/sessions/{id}/reports?year=&month=` (월간 리포트 조회)
+
+        ## 🔗 참고
+        - 와이어프레임: `docs/wireframes/figma/Main_Dashboard.svg`, `docs/wireframes/figma/Event_Log_Drawer.svg`
+        - PRD: `PRD_expanded.md`


### PR DESCRIPTION
## 개요
T4-1~T4-3 이슈 템플릿에 연관 API/참고(와이어프레임, PRD) 섹션을 추가해 작성 편의성을 높였습니다.

## 변경 내용
- T4-1: 참고 섹션(PRD, 메인/모바일 와이어프레임) 추가
- T4-2: 연관 API(세션 시작) + 참고(다이얼로그 와이어프레임/PRD) 추가
- T4-3: 연관 API(시뮬레이트/리포트) + 참고(대시보드/이벤트 드로어/PRD) 추가

## 영향 범위
- 신규 이슈 생성 폼에 추가 정보 표시

## 검증 방법
- GitHub > New issue > 템플릿 선택(T4-1/2/3) 화면에서 추가 섹션 노출 확인
