### PR TITLE
chore(docker): add local Postgres compose for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ frontend/node_modules/
 frontend/dist/
 frontend/.vite/
 frontend/.env.local
+
+# Docker local env file
+docker/.env

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -40,6 +40,31 @@ cp docker/.env.example docker/.env
 ./docker/clean.sh
 ```
 
+## 로컬 개발: Postgres만 compose로 실행
+백엔드는 로컬 JVM에서 실행(`./gradlew bootRun`), 데이터베이스는 Docker(Postgres)로 실행하는 구성입니다. `application-local.yaml`은 기본적으로 `localhost:5432`의 Postgres를 사용하도록 되어 있습니다.
+
+1) 환경 파일 준비(선택)
+```bash
+cp docker/.env.example docker/.env
+# 필요 시 POSTGRES_* 값 수정 (기본값은 application-local.yaml과 일치)
+```
+
+2) Postgres 실행
+```bash
+./docker/run-db.sh
+# 준비되면 로컬에서 백엔드 실행: ./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+3) 종료
+```bash
+./docker/stop-db.sh
+```
+
+구성 파일: `docker/docker-compose.db.yml`
+ - 포트: `5432` 노출 (변경 시 `docker/.env`의 `POSTGRES_PORT` 수정)
+ - DB/계정: `strategic_city_simulator` / `postgres` / `password`
+ - 데이터 영속화: 볼륨 `pg_data`
+
 ## 동작 방식
 - 빌드 스테이지: `gradle:8.7-jdk21` 이미지에서 `gradle clean build -x test` 실행 후 `build/libs/*.jar` 생성
 - 런타임 스테이지: `eclipse-temurin:21-jre` 이미지에서 JAR 실행(`java $JAVA_OPTS -jar /app/app.jar`)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,3 +9,9 @@ PORT=8080
 SPRING_PROFILES_ACTIVE=local
 JAVA_OPTS=
 
+# --- Postgres (for local compose db) ---
+# These values should match src/main/resources/application-local.yaml
+POSTGRES_DB=strategic_city_simulator
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_PORT=5432

--- a/docker/docker-compose.db.yml
+++ b/docker/docker-compose.db.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    container_name: citysim-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-strategic_city_simulator}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+
+volumes:
+  pg_data:
+

--- a/docker/run-db.sh
+++ b/docker/run-db.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+  ENV_OPT=("--env-file" "$ENV_FILE")
+else
+  ENV_OPT=()
+fi
+
+echo "[run-db] docker compose up -d (Postgres only)"
+docker compose "${ENV_OPT[@]}" -f "$SCRIPT_DIR/docker-compose.db.yml" up -d
+echo "[run-db] Postgres is starting. Logs: docker compose -f $SCRIPT_DIR/docker-compose.db.yml logs -f"
+

--- a/docker/stop-db.sh
+++ b/docker/stop-db.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+  ENV_OPT=("--env-file" "$ENV_FILE")
+else
+  ENV_OPT=()
+fi
+
+echo "[stop-db] docker compose down (Postgres only)"
+docker compose "${ENV_OPT[@]}" -f "$SCRIPT_DIR/docker-compose.db.yml" down
+


### PR DESCRIPTION
## 개요
로컬 환경에서 서버를 JVM으로 구동할 때 필요한 Postgres를 docker-compose로 손쉽게 기동/정지할 수 있도록 구성했습니다.

## 변경 내용
- docker/docker-compose.db.yml: Postgres 16 (DB/USER/PASSWORD 기본값은 application-local.yaml과 일치)
- docker/run-db.sh, docker/stop-db.sh: DB 전용 compose up/down 스크립트
- docker/.env.example: POSTGRES_* 변수 추가 (포트/계정/DB명)
- README-Docker.md: '로컬 개발: Postgres만 compose로 실행' 섹션 추가
- .gitignore: docker/.env 무시

## 사용 방법
1) cp docker/.env.example docker/.env (선택)
2) ./docker/run-db.sh (DB 기동)
3) ./gradlew bootRun --args='--spring.profiles.active=local' (백엔드 로컬 실행)
4) ./docker/stop-db.sh (DB 종료)

## 참고
- DB 접속: localhost:5432 / DB: strategic_city_simulator / user: postgres / pass: password
- 프론트엔드(dev): http://localhost:5173  → 백엔드(8080)와 프록시로 연동
