### PR TITLE
fix(frontend): add @vitejs/plugin-react devDependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,10 +13,10 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.3"
   }
 }
-


### PR DESCRIPTION
## 원인\nVite dev 서버 시작 시 vite.config.ts에서 '@vitejs/plugin-react'를 import 하지만, devDependencies에 해당 패키지가 없어 모듈 해석이 실패했습니다.\n\n## 변경\n- frontend/package.json: devDependencies에  추가\n\n## 확인 방법\n1) cd frontend\n2) npm install\n3) npm run dev\n→ dev 서버 정상 기동되는지 확인(헬스체크 UI 표시)\n