### PR TITLE
- feat(frontend): add New Game Dialog (T4-2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiBaseUrl, getHealth } from './api/client';
+import NewGameDialog from './components/NewGameDialog';
+import type { StartSessionResponse } from './api/sessions';
 
 export default function App() {
   const [health, setHealth] = useState<string>('unknown');
   const base = useMemo(() => apiBaseUrl(), []);
+  const [open, setOpen] = useState(false);
+  const [session, setSession] = useState<StartSessionResponse | null>(null);
 
   useEffect(() => {
     getHealth()
@@ -16,7 +20,7 @@ export default function App() {
       <h1>Strategic City Simulator</h1>
       <p className="muted">Frontend Bootstrap (Vite + React)</p>
 
-      <section>
+      <section style={{ marginBottom: 16 }}>
         <h2>Backend 연결 상태</h2>
         <ul>
           <li>
@@ -31,7 +35,25 @@ export default function App() {
           <code>http://localhost:8080</code>으로 전달합니다.
         </p>
       </section>
+
+      <section>
+        <h2>새 게임</h2>
+        <p className="hint">난이도를 선택해 새 게임 세션을 시작합니다.</p>
+        <div className="actions">
+          <button className="btn primary" onClick={() => setOpen(true)}>새 게임 시작</button>
+        </div>
+        {session && (
+          <div style={{ marginTop: 12 }}>
+            <p>세션이 생성되었습니다. 세션 ID: <code>{session.sessionId}</code> (난이도: {session.difficulty})</p>
+          </div>
+        )}
+      </section>
+
+      <NewGameDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onStarted={(res) => setSession(res)}
+      />
     </div>
   );
 }
-

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,0 +1,25 @@
+export type Difficulty = 'EASY' | 'NORMAL' | 'HARD';
+
+export interface StartSessionResponse {
+  sessionId: number;
+  difficulty: Difficulty;
+  scores: Record<string, number>;
+}
+
+import { apiBaseUrl } from './client';
+
+export async function startSession(difficulty: Difficulty): Promise<StartSessionResponse> {
+  const base = apiBaseUrl();
+  const url = (base ?? '') + '/api/v1/sessions';
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ difficulty }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to start session: ${res.status} ${text}`);
+  }
+  return (await res.json()) as StartSessionResponse;
+}
+

--- a/frontend/src/components/NewGameDialog.tsx
+++ b/frontend/src/components/NewGameDialog.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import type { Difficulty, StartSessionResponse } from '../api/sessions';
+import { startSession } from '../api/sessions';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onStarted: (res: StartSessionResponse) => void;
+};
+
+const difficulties: Difficulty[] = ['EASY', 'NORMAL', 'HARD'];
+
+export default function NewGameDialog({ open, onClose, onStarted }: Props) {
+  const [difficulty, setDifficulty] = useState<Difficulty>('NORMAL');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+      setLoading(false);
+      setDifficulty('NORMAL');
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleStart = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await startSession(difficulty);
+      onStarted(res);
+      onClose();
+    } catch (e: any) {
+      setError(e?.message ?? '시작 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <h2>새 게임</h2>
+        <div className="field">
+          <label>난이도</label>
+          <div className="radio-group">
+            {difficulties.map((d) => (
+              <label key={d} className="radio">
+                <input
+                  type="radio"
+                  name="difficulty"
+                  value={d}
+                  checked={difficulty === d}
+                  onChange={() => setDifficulty(d)}
+                  disabled={loading}
+                />
+                <span>{d}</span>
+              </label>
+            ))}
+          </div>
+          <p className="hint">설명: 세수/효율/이벤트 빈도가 난이도에 따라 달라집니다.</p>
+        </div>
+
+        {error && <p className="error">{error}</p>}
+
+        <div className="actions">
+          <button className="btn" onClick={onClose} disabled={loading}>
+            취소
+          </button>
+          <button className="btn primary" onClick={handleStart} disabled={loading}>
+            {loading ? '시작 중…' : '시작하기'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -20,3 +20,17 @@ section { background: #1f2937; border: 1px solid #374151; border-radius: 8px; pa
 .hint { color: var(--muted); font-size: 14px; }
 code { background: #111827; padding: 2px 6px; border-radius: 4px; color: var(--accent); }
 
+/* Dialog */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.35);
+  display: flex; align-items: center; justify-content: center;
+}
+.modal { background: #111827; border: 1px solid #374151; border-radius: 10px; width: 420px; padding: 20px; }
+.field { margin: 12px 0 16px; }
+.radio-group { display: flex; gap: 12px; margin-top: 8px; }
+.radio input { margin-right: 6px; }
+.actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+.btn { background: #374151; color: #e5e7eb; border: 1px solid #4b5563; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+.btn.primary { background: #2563eb; border-color: #2563eb; }
+.btn:disabled { opacity: .6; cursor: default; }
+.error { color: #fca5a5; margin: 8px 0; }


### PR DESCRIPTION
**브랜치**
- base: `main`
- head: `feat/frontend-new-game-dialog-T4-2`

**본문(Description)**

- 개요: PRD_expanded.md와 이슈 #42에 따라 새 게임 시작 다이얼로그를 추가했습니다
. 난이도(EASY/NORMAL/HARD) 선택 후 기존 백엔드 엔드포인트를 호출해 GameSession을
 생성합니다. 시작/취소 동작을 포함합니다.
- 관련 이슈: Fixes #42

- 변경 내용:
  - `frontend/src/api/sessions.ts`: `POST /api/v1/sessions` 호출 util 추가, 타입
 정의(Difficulty, StartSessionResponse)
  - `frontend/src/components/NewGameDialog.tsx`: 난이도 선택 라디오 + 시작/취소
버튼 + 로딩/에러 상태
  - `frontend/src/App.tsx`: “새 게임 시작” 버튼과 다이얼로그 연결, 생성된 `sessi
onId` 표시
  - `frontend/src/styles.css`: 다이얼로그/버튼 공통 스타일 추가

- 동작 요약:
  - 시작: 다이얼로그에서 난이도 선택 → 시작 → 세션 생성 성공 시 닫힘 + 화면에 `s
essionId` 표시
  - 취소: 다이얼로그 닫기

- 테스트 방법:
  - DB: `./docker/run-db.sh`
  - 백엔드: `./gradlew bootRun --args='--spring.profiles.active=local'`
  - 프론트엔드: `cd frontend && npm install && npm run dev`
  - 브라우저: `http://localhost:5173`
  - UI 동작: “새 게임 시작” 클릭 → 난이도 선택 → 시작 → Network 탭에서 `POST /ap
i/v1/sessions` 201 Created + JSON 응답 확인, 화면에 `sessionId` 출력 확인


- 스크린샷(선택):
  - 다이얼로그 표시 화면
  - 세션 생성 후 `sessionId` 표기 화면

- 영향 범위:
  - 프론트엔드 신규 기능 추가, 기존 백엔드 API 사용
  - CORS는 이미 `localhost:5173` 허용(WebCorsConfig)되어 있어 추가 변경 없음

- 호환/리스크:
  - 프런트엔드 개발 서버에서만 동작 영향, 서버 API 계약(StartSessionRequest/Resp
onse) 변경 없으면 리스크 낮음

- 롤백 계획:
  - 문제가 있으면 `frontend/src/api/sessions.ts`, `frontend/src/components/NewGa
meDialog.tsx`, `frontend/src/App.tsx`, `frontend/src/styles.css` 변경분을 되돌리
면 됩니다.

- 후속 작업(참고):
  - T4-3(Main Dashboard): 예산 슬라이더, 지표/이벤트 로그 표시, 시뮬레이트 연동