### PR TITLE
feat(frontend): implement Main Dashboard (T4-3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { apiBaseUrl, getHealth } from './api/client';
 import NewGameDialog from './components/NewGameDialog';
 import type { StartSessionResponse } from './api/sessions';
+import Dashboard from './components/Dashboard';
 
 export default function App() {
   const [health, setHealth] = useState<string>('unknown');
@@ -54,6 +55,12 @@ export default function App() {
         onClose={() => setOpen(false)}
         onStarted={(res) => setSession(res)}
       />
+
+      {session && (
+        <div style={{ marginTop: 16 }}>
+          <Dashboard sessionId={session.sessionId} initialScores={session.scores as any} />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/api/simulations.ts
+++ b/frontend/src/api/simulations.ts
@@ -1,0 +1,29 @@
+import { apiBaseUrl } from './client';
+import type { CategoryType } from './types';
+
+export interface SimulateResponse {
+  before: Record<CategoryType, number>;
+  after: Record<CategoryType, number>;
+  delta: Record<CategoryType, number>;
+  events: { name: string; type: string; impact: Record<CategoryType, number> }[];
+  overallIndex: number;
+}
+
+export async function simulateMonth(
+  sessionId: number,
+  ratios: Record<CategoryType, number>
+): Promise<SimulateResponse> {
+  const base = apiBaseUrl();
+  const url = (base ?? '') + `/api/v1/sessions/${sessionId}/simulate`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ budgetRatios: ratios }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to simulate: ${res.status} ${text}`);
+  }
+  return (await res.json()) as SimulateResponse;
+}
+

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,26 @@
+export type CategoryType =
+  | 'DEFENSE'
+  | 'DIPLOMACY'
+  | 'ECONOMY'
+  | 'POLITICS'
+  | 'CULTURE'
+  | 'ENVIRONMENT';
+
+export const CATEGORY_ORDER: CategoryType[] = [
+  'ECONOMY',
+  'POLITICS',
+  'DEFENSE',
+  'DIPLOMACY',
+  'CULTURE',
+  'ENVIRONMENT',
+];
+
+export const CATEGORY_LABEL: Record<CategoryType, string> = {
+  DEFENSE: '국방',
+  DIPLOMACY: '외교',
+  ECONOMY: '경제',
+  POLITICS: '정치',
+  CULTURE: '문화',
+  ENVIRONMENT: '환경',
+};
+

--- a/frontend/src/components/BudgetPanel.tsx
+++ b/frontend/src/components/BudgetPanel.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import type { CategoryType } from '../api/types';
+import { CATEGORY_ORDER, CATEGORY_LABEL } from '../api/types';
+
+type Props = {
+  ratios: Record<CategoryType, number>; // 0.0~1.0
+  onChange: (next: Record<CategoryType, number>) => void;
+};
+
+function clamp01(x: number) { return Math.max(0, Math.min(1, x)); }
+
+// Equalize others so that total remains 1.0.
+function rebalance(
+  ratios: Record<CategoryType, number>,
+  changedKey: CategoryType,
+  newValue: number
+): Record<CategoryType, number> {
+  const next = { ...ratios } as Record<CategoryType, number>;
+  next[changedKey] = clamp01(newValue);
+  const keys = CATEGORY_ORDER.filter((k) => k !== changedKey);
+  const sumOthers = keys.reduce((s, k) => s + next[k], 0);
+  const targetOthers = 1 - next[changedKey];
+  if (targetOthers <= 0) {
+    keys.forEach((k) => (next[k] = 0));
+    return next;
+  }
+  if (sumOthers === 0) {
+    const even = targetOthers / keys.length;
+    keys.forEach((k) => (next[k] = even));
+    return next;
+  }
+  // Equal proportional scaling to fit targetOthers
+  const scale = targetOthers / sumOthers;
+  keys.forEach((k) => (next[k] = next[k] * scale));
+  return next;
+}
+
+export default function BudgetPanel({ ratios, onChange }: Props) {
+  const percent = (k: CategoryType) => Math.round((ratios[k] ?? 0) * 100);
+  const totalPct = useMemo(
+    () => Math.round(CATEGORY_ORDER.reduce((s, k) => s + (ratios[k] ?? 0), 0) * 100),
+    [ratios]
+  );
+
+  return (
+    <div>
+      <h3>월간 예산 배분</h3>
+      <p className="hint">합계가 100%가 되도록 자동 균형 조정됩니다.</p>
+      <div style={{ display: 'grid', gap: 12 }}>
+        {CATEGORY_ORDER.map((k) => (
+          <div key={k}>
+            <label style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>{CATEGORY_LABEL[k]}</span>
+              <span>{percent(k)}%</span>
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={percent(k)}
+              onChange={(e) => {
+                const v = Number(e.target.value) / 100;
+                onChange(rebalance(ratios, k, v));
+              }}
+            />
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 8 }} className="hint">합계: {totalPct}%</div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import type { CategoryType } from '../api/types';
+import { CATEGORY_ORDER, CATEGORY_LABEL } from '../api/types';
+import BudgetPanel from './BudgetPanel';
+import { simulateMonth } from '../api/simulations';
+
+type Props = {
+  sessionId: number;
+  initialScores: Record<CategoryType, number>;
+};
+
+export default function Dashboard({ sessionId, initialScores }: Props) {
+  const [scores, setScores] = useState<Record<CategoryType, number>>(initialScores);
+  const [delta, setDelta] = useState<Record<CategoryType, number>>(() => {
+    const d: Record<CategoryType, number> = { DEFENSE: 0, DIPLOMACY: 0, ECONOMY: 0, POLITICS: 0, CULTURE: 0, ENVIRONMENT: 0 };
+    return d;
+  });
+  const [ratios, setRatios] = useState<Record<CategoryType, number>>({
+    DEFENSE: 1 / 6,
+    DIPLOMACY: 1 / 6,
+    ECONOMY: 1 / 6,
+    POLITICS: 1 / 6,
+    CULTURE: 1 / 6,
+    ENVIRONMENT: 1 / 6,
+  });
+  const [events, setEvents] = useState<{ name: string; type: string; impact: Record<CategoryType, number> }[]>([]);
+  const overall = useMemo(() => {
+    const w: Record<CategoryType, number> = {
+      ECONOMY: 0.25, POLITICS: 0.20, DEFENSE: 0.15, DIPLOMACY: 0.15, CULTURE: 0.15, ENVIRONMENT: 0.10,
+    } as any;
+    let sum = 0;
+    for (const k of CATEGORY_ORDER) sum += (scores[k] ?? 0) * (w[k] ?? 0);
+    return Math.round(sum * 10) / 10;
+  }, [scores]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runSimulate = async () => {
+    setLoading(true); setError(null);
+    try {
+      const res = await simulateMonth(sessionId, ratios);
+      setScores(res.after as any);
+      setDelta(res.delta as any);
+      setEvents(res.events);
+    } catch (e: any) {
+      setError(e?.message ?? '시뮬레이션 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      <section>
+        <h2>지표 요약</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 12 }}>
+          {CATEGORY_ORDER.map((k) => (
+            <div key={k} style={{ border: '1px solid #374151', borderRadius: 8, padding: 12 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <strong>{CATEGORY_LABEL[k]}</strong>
+                <span>{scores[k] ?? 0}</span>
+              </div>
+              <div className="hint">{delta[k] ? (delta[k] > 0 ? `▲ +${delta[k]}` : `▼ ${delta[k]}`) : '▬ ±0'}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 8 }} className="hint">종합 도시 지수(가중): {overall}</div>
+      </section>
+
+      <section>
+        <BudgetPanel ratios={ratios} onChange={setRatios} />
+        <div className="actions" style={{ marginTop: 12 }}>
+          <button className="btn primary" onClick={runSimulate} disabled={loading}>
+            {loading ? '턴 진행 중…' : '턴 진행 ▶'}
+          </button>
+        </div>
+        {error && <p className="error">{error}</p>}
+      </section>
+
+      <section>
+        <h2>이벤트 로그(최근 턴)</h2>
+        {events.length === 0 ? (
+          <p className="hint">최근 턴 이벤트 없음</p>
+        ) : (
+          <ul>
+            {events.map((e, idx) => (
+              <li key={idx}>
+                <strong>{e.name}</strong> <span className="hint">({e.type})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## 개요\nPRD_expanded.md 및 이슈 #43에 따라 단일 사용자용 메인 대시보드를 구현했습니다. 카테고리 지표 표시, 예산 슬라이더(합계 자동 100%), 턴 진행(시뮬레이트), 이벤트 로그 표시를 포함합니다.\n\nFixes #43\n\n## 변경 내용\n- Dashboard\n  - 카테고리 카드: 현재 점수 + 전월 대비 변화(Δ)\n  - 종합 도시 지수(가중 평균) 표시\n  - 이벤트 로그(최근 턴) 표시\n- BudgetPanel\n  - 6개 카테고리 슬라이더, 변경 시 나머지 균등/비례 재분배로 합계 100% 유지\n- API 연동\n  - POST /api/v1/sessions/{id}/simulate 호출하여 after/delta/events/overall 수신\n  - 타입 정의(CategoryType 등)와 유틸 추가\n\n## 사용 방법(로컬)\n1) DB: ./docker/run-db.sh\n2) 백엔드: ./gradlew bootRun --args='--spring.profiles.active=local'\n3) 프론트엔드: cd frontend && npm install && npm run dev\n4) UI: 새 게임 시작 → 대시보드에서 슬라이더 조정 → 턴 진행 ▶\n\n## 참고\n- PRD_expanded.md의 카테고리/가중치 반영(종합 지수 계산)\n- 미리보기(예상 변화)는 서버 변동을 야기하지 않도록 향후 클라이언트 추정 모듈로 분리 예정\n