### PR TITLE
docs(frontend): routing-based UX flow (landing → sessions/:id)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -66,7 +66,8 @@ frontend/
 - 첫 화면(Landing)
   - 선택지: [새 게임 시작] / [기존 게임 선택]
   - 새 게임: `NewGameDialog`를 열어 난이도 선택 → `POST /api/v1/sessions` 호출 → 세션 생성
-  - 기존 게임: 로컬 저장된 최근 세션 ID 또는 백엔드 목록(추가 예정)을 선택 → 해당 세션으로 진입
+  - 기존 게임: (권장) 세션 ID 입력 → 해당 세션 URL로 이동(`/sessions/:id`)
+    - 선택적으로 로컬에 저장된 최근 세션 ID를 불러와 빠른 진입 버튼 제공
 
 - 세션 진입(Main Dashboard)
   - 컴포넌트: `Dashboard`
@@ -76,11 +77,16 @@ frontend/
 - 상태 전이 제안(App 레벨)
   - 상태 A(세션 없음): Landing + `NewGameDialog`
   - 상태 B(세션 있음): `Dashboard` 렌더링
-  - 세션 지속성: `localStorage`에 `sessionId` 보관 → 재방문 시 “최근 세션 계속하기” 제공
+  - 세션 지속성: 기본은 URL 기반(`/sessions/:id`)으로 복원. `localStorage`는 선택적 편의 기능(“최근 세션 계속하기”)으로만 사용
 
 - 라우팅(선택)
-  - 간단 상태 전이로도 가능하나, 필요 시 `react-router` 도입 제안:
+  - 권장: `react-router` 도입으로 딥링크/새로고침 대응
     - `/` → Landing, `/sessions/:id` → Dashboard
-    - 브라우저 새로고침/공유 링크에 유리
+    - 새 게임 성공 시 `navigate('/sessions/{id}')`
+    - Dashboard 마운트 시 `GET /api/v1/sessions/{id}/reports`로 초기 상태 복원
 
-현재 구현은 App에서 “새 게임 시작 → NewGameDialog → 세션 생성 시 Dashboard 렌더”까지 연결되어 있습니다. 위 제안(Landing + 기존 세션 선택/지속성 + 선택적 라우팅)을 반영하면 와이어프레임 의도와 완전히 일치하는 구조가 됩니다. 필요하시면 해당 구조로 리팩터링 PR을 준비하겠습니다.
+ 에러 처리 가이드
+ - 존재하지 않는 ID: “세션을 찾을 수 없음” 안내 + [새 게임 시작] CTA
+ - 네트워크 오류: 재시도/가이드 표시
+
+ 현재 구현은 App에서 “새 게임 시작 → NewGameDialog → 세션 생성 시 Dashboard 렌더”까지 연결되어 있습니다. 위 제안(라우팅 기반 Landing/세션 복원/선택적 localStorage)을 반영하면 와이어프레임 의도와 완전히 일치하는 구조가 됩니다. 필요하시면 해당 구조로 리팩터링 PR을 준비하겠습니다.


### PR DESCRIPTION
## 개요
frontend/README.md에 라우팅 기반 UX 흐름을 보강했습니다. 랜딩() →  진입, NewGameDialog 성공 시 네비게이션, Dashboard 마운트 시 reports 복원 흐름 등을 명시합니다.

## 변경 내용
- 기존 UX 제안 섹션에 다음 포인트 추가/정제
  - 기존 세션: ID 입력 →  네비게이션(권장)
  - 세션 지속성: 기본은 URL 복원, localStorage는 선택적 편의 기능
  - 라우팅 권장:  기반 경로 구성 및 초기 데이터 로딩 전략
  - 에러 처리 가이드(존재하지 않는 ID, 네트워크 오류)

## 영향
- 코드 변경 없음(문서 업데이트). 이슈 #51의 구현 가이드로 활용 가능합니다.