### PR TITLE
feat(frontend): landing + routing to sessions/:id (Fixes #51)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiBaseUrl, getHealth } from './api/client';
-import NewGameDialog from './components/NewGameDialog';
-import type { StartSessionResponse } from './api/sessions';
-import Dashboard from './components/Dashboard';
+import { Routes, Route, Link } from 'react-router-dom';
+import Landing from './pages/Landing';
+import DashboardRoute from './pages/DashboardRoute';
 
 export default function App() {
   const [health, setHealth] = useState<string>('unknown');
   const base = useMemo(() => apiBaseUrl(), []);
-  const [open, setOpen] = useState(false);
-  const [session, setSession] = useState<StartSessionResponse | null>(null);
+  // Routing 기반으로 전환하여 App 레벨의 세션 상태는 제거
 
   useEffect(() => {
     getHealth()
@@ -37,30 +36,14 @@ export default function App() {
         </p>
       </section>
 
-      <section>
-        <h2>새 게임</h2>
-        <p className="hint">난이도를 선택해 새 게임 세션을 시작합니다.</p>
-        <div className="actions">
-          <button className="btn primary" onClick={() => setOpen(true)}>새 게임 시작</button>
-        </div>
-        {session && (
-          <div style={{ marginTop: 12 }}>
-            <p>세션이 생성되었습니다. 세션 ID: <code>{session.sessionId}</code> (난이도: {session.difficulty})</p>
-          </div>
-        )}
-      </section>
+      <nav style={{ marginBottom: 16 }}>
+        <Link className="btn" to="/">홈</Link>
+      </nav>
 
-      <NewGameDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        onStarted={(res) => setSession(res)}
-      />
-
-      {session && (
-        <div style={{ marginTop: 16 }}>
-          <Dashboard sessionId={session.sessionId} initialScores={session.scores as any} />
-        </div>
-      )}
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/sessions/:id" element={<DashboardRoute />} />
+      </Routes>
     </div>
   );
 }

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,0 +1,29 @@
+import { apiBaseUrl } from './client';
+import type { CategoryType } from './types';
+
+export interface ReportEventDto {
+  type: string;
+  description: string;
+  occurredAt: string;
+}
+
+export interface ReportResponse {
+  year: number | null;
+  month: number | null;
+  scores: Record<CategoryType, number>;
+  overall: number;
+  events: ReportEventDto[];
+  cumulativeByType: Record<string, number>;
+}
+
+export async function getLatestReport(sessionId: number): Promise<ReportResponse> {
+  const base = apiBaseUrl();
+  const url = (base ?? '') + `/api/v1/sessions/${sessionId}/reports`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to load report: ${res.status} ${text}`);
+  }
+  return (await res.json()) as ReportResponse;
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles.css'
+import { BrowserRouter } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )
-

--- a/frontend/src/pages/DashboardRoute.tsx
+++ b/frontend/src/pages/DashboardRoute.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import Dashboard from '../components/Dashboard';
+import { getLatestReport } from '../api/reports';
+import type { CategoryType } from '../api/types';
+
+export default function DashboardRoute() {
+  const { id } = useParams();
+  const sessionId = Number(id);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [scores, setScores] = useState<Record<CategoryType, number> | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      if (!Number.isFinite(sessionId) || sessionId <= 0) {
+        setError('잘못된 세션 ID입니다.');
+        setLoading(false);
+        return;
+      }
+      try {
+        const rep = await getLatestReport(sessionId);
+        if (!mounted) return;
+        setScores(rep.scores as any);
+      } catch (e: any) {
+        setError(e?.message ?? '리포트 로딩 실패');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      mounted = false;
+    };
+  }, [sessionId]);
+
+  if (loading) return <div className="container"><p>로딩 중…</p></div>;
+  if (error) return (
+    <div className="container">
+      <p className="error" style={{ marginBottom: 12 }}>{error}</p>
+      <Link className="btn" to="/">새 게임 시작으로 돌아가기</Link>
+    </div>
+  );
+  if (!scores) return null;
+
+  return (
+    <div className="container">
+      <Dashboard sessionId={sessionId} initialScores={scores} />
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NewGameDialog from '../components/NewGameDialog';
+
+export default function Landing() {
+  const [open, setOpen] = useState(false);
+  const [existingId, setExistingId] = useState('');
+  const navigate = useNavigate();
+
+  const gotoExisting = () => {
+    const id = Number(existingId);
+    if (!Number.isFinite(id) || id <= 0) return;
+    navigate(`/sessions/${id}`);
+  };
+
+  return (
+    <div className="container">
+      <h1>Strategic City Simulator</h1>
+      <p className="muted">세션을 선택하여 시작하세요.</p>
+
+      <section style={{ marginBottom: 16 }}>
+        <h2>새 게임</h2>
+        <div className="actions">
+          <button className="btn primary" onClick={() => setOpen(true)}>새 게임 시작</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>기존 게임</h2>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input
+            type="number"
+            inputMode="numeric"
+            placeholder="세션 ID 입력"
+            value={existingId}
+            onChange={(e) => setExistingId(e.target.value)}
+            style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid #4b5563', background: '#111827', color: '#e5e7eb' }}
+          />
+          <button className="btn" onClick={gotoExisting} disabled={!existingId}>이동</button>
+        </div>
+        <p className="hint" style={{ marginTop: 6 }}>예: /sessions/123 으로 이동합니다.</p>
+      </section>
+
+      <NewGameDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onStarted={(res) => navigate(`/sessions/${res.sessionId}`)}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## 개요
frontend/README.md의 UX 제안에 따라 라우팅 기반 초기 흐름을 구현했습니다. 랜딩()에서 새 게임/기존 세션 선택 → 로 대시보드 진입, 대시보드는 마운트 시 보고서를 로>딩하여 상태를 복원합니다.

Fixes #51

## 변경 내용
- 의존성:  도입,  래핑
- 랜딩 페이지:  (새 게임 다이얼로그/기존 세션 ID 이동)
- 대시보드 라우트:  (마운트 시 )
- API:  (리포트 로더)
- App 라우팅: 로 와  구성, 앱 레벨 세션 상태 제거

## 확인 방법
1) DB: ./docker/run-db.sh
2) 백엔드: ./gradlew bootRun --args='--spring.profiles.active=local'
3) 프론트엔드: cd frontend && npm install && npm run dev
4) 브라우저:
   - /: 새 게임 시작 → 다이얼로그에서 난이도 선택 → 생성 후 자동 이동()
   - /sessions/{id}: 새로고침해도 리포트로 상태 복원 후 대시보드 표시

## 참고
- PRD_expanded.md, docs/wireframes/README.md
- localStorage 사용은 선택적(최근 세션 빠른 이동용)이며 기본은 URL 기반 복원