### PR TITLE
feat(backend): difficulty-based initial budget + treasury (Fixes #57)

### DIFF
--- a/src/main/java/com/example/domain/GameSession.java
+++ b/src/main/java/com/example/domain/GameSession.java
@@ -26,6 +26,11 @@ public class GameSession {
 
     private LocalDateTime createdAt;
 
+    // PRD §6 난이도별 초기 예산(원) 및 현재 금고 잔액(원)
+    // 마이그레이션 V2에서 컬럼 추가: initial_budget, treasury
+    private Long initialBudget;
+    private Long treasury;
+
     protected GameSession() {
     }
 
@@ -58,5 +63,21 @@ public class GameSession {
     public void incrementMonth() {
         int cur = this.currentMonth == null ? 0 : this.currentMonth;
         this.currentMonth = cur + 1;
+    }
+
+    public Long getInitialBudget() {
+        return initialBudget;
+    }
+
+    public void setInitialBudget(Long initialBudget) {
+        this.initialBudget = initialBudget;
+    }
+
+    public Long getTreasury() {
+        return treasury;
+    }
+
+    public void setTreasury(Long treasury) {
+        this.treasury = treasury;
     }
 }

--- a/src/main/java/com/example/session/StartSessionService.java
+++ b/src/main/java/com/example/session/StartSessionService.java
@@ -25,6 +25,11 @@ public class StartSessionService {
     @Transactional
     public Result start(Difficulty difficulty) {
         GameSession session = new GameSession(difficulty, 0, LocalDateTime.now());
+
+        long initialBudget = mapInitialBudgetByDifficulty(difficulty);
+        session.setInitialBudget(initialBudget);
+        session.setTreasury(initialBudget);
+
         session = gameSessionRepository.save(session);
 
         EnumMap<CategoryType, Integer> initialScores = new EnumMap<>(CategoryType.class);
@@ -34,13 +39,22 @@ public class StartSessionService {
             categoryScoreRepository.save(new CategoryScore(c, score, session));
         }
 
-        return new Result(session.getId(), difficulty, initialScores);
+        return new Result(session.getId(), difficulty, initialScores, session.getInitialBudget(), session.getTreasury());
     }
 
     public record Result(
             Long sessionId,
             Difficulty difficulty,
-            Map<CategoryType, Integer> scores
+            Map<CategoryType, Integer> scores,
+            Long initialBudget,
+            Long treasury
     ) {}
-}
 
+    private long mapInitialBudgetByDifficulty(Difficulty difficulty) {
+        return switch (difficulty) {
+            case EASY -> 1_500_000_000L;   // 15억 원
+            case NORMAL -> 1_000_000_000L; // 10억 원
+            case HARD -> 800_000_000L;     // 8억 원
+        };
+    }
+}

--- a/src/main/java/com/example/web/SessionsController.java
+++ b/src/main/java/com/example/web/SessionsController.java
@@ -48,7 +48,13 @@ public class SessionsController {
     public ResponseEntity<StartSessionResponse> start(@Validated @RequestBody StartSessionRequest request) {
         Difficulty difficulty = request.getDifficulty();
         var result = startSessionService.start(difficulty);
-        var body = new StartSessionResponse(result.sessionId(), result.difficulty(), result.scores());
+        var body = new StartSessionResponse(
+                result.sessionId(),
+                result.difficulty(),
+                result.scores(),
+                result.initialBudget(),
+                result.treasury()
+        );
         return ResponseEntity.created(URI.create("/api/v1/sessions/" + result.sessionId()))
                 .body(body);
     }

--- a/src/main/java/com/example/web/dto/StartSessionResponse.java
+++ b/src/main/java/com/example/web/dto/StartSessionResponse.java
@@ -13,11 +13,18 @@ public class StartSessionResponse {
     private Difficulty difficulty;
     @Schema(description = "초기 카테고리 점수(0~100)")
     private Map<CategoryType, Integer> scores;
+    @Schema(description = "난이도에 따른 초기 예산(원)")
+    private Long initialBudget;
+    @Schema(description = "현재 금고 잔액(원)")
+    private Long treasury;
 
-    public StartSessionResponse(Long sessionId, Difficulty difficulty, Map<CategoryType, Integer> scores) {
+    public StartSessionResponse(Long sessionId, Difficulty difficulty, Map<CategoryType, Integer> scores,
+                                Long initialBudget, Long treasury) {
         this.sessionId = sessionId;
         this.difficulty = difficulty;
         this.scores = scores;
+        this.initialBudget = initialBudget;
+        this.treasury = treasury;
     }
 
     public Long getSessionId() {
@@ -31,5 +38,12 @@ public class StartSessionResponse {
     public Map<CategoryType, Integer> getScores() {
         return scores;
     }
-}
 
+    public Long getInitialBudget() {
+        return initialBudget;
+    }
+
+    public Long getTreasury() {
+        return treasury;
+    }
+}

--- a/src/main/resources/db/migration/V2__difficulty_params.sql
+++ b/src/main/resources/db/migration/V2__difficulty_params.sql
@@ -1,0 +1,5 @@
+-- V2: 난이도별 초기 예산/금고 컬럼 추가
+ALTER TABLE game_sessions
+    ADD COLUMN IF NOT EXISTS initial_budget BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS treasury BIGINT NOT NULL DEFAULT 0;
+


### PR DESCRIPTION
## 개요
PRD_expanded.md §6(난이도별 파라미터)의 초기 예산을 백엔드에 반영했습니다. 세션 시작 시 난이도에 따라 초기 예산을 지급하고, 현재 금고 잔액을 동일 금액으로 초기화합니다.

Fixes #57

## 변경 내용
- 도메인: GameSession에 ,  필드 추가
- 마이그레이션: V2__difficulty_params.sql로 game_sessions에 컬럼 추가
- 서비스: StartSessionService에서 난이도→초기 예산 매핑(15/10/8억) 및 저장
- API: StartSessionResponse에 ,  노출

## 참고
- 이후 단계에서 세수 성장률/투자효율/이벤트 빈도 등의 난이도 파라미터도 세션에 보관하거나 환경에서 주입 가능
- 재정 흐름(세수/지출/잔액 갱신)은 T4-3/후속 이슈에서 확장 예정