### PR TITLE
feat(frontend): show initial budget/treasury on Dashboard

### DIFF
--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -4,6 +4,8 @@ export interface StartSessionResponse {
   sessionId: number;
   difficulty: Difficulty;
   scores: Record<string, number>;
+  initialBudget: number; // 원 단위
+  treasury: number;      // 현재 금고 잔액(원)
 }
 
 import { apiBaseUrl } from './client';
@@ -22,4 +24,3 @@ export async function startSession(difficulty: Difficulty): Promise<StartSession
   }
   return (await res.json()) as StartSessionResponse;
 }
-

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -2,14 +2,16 @@ import { useMemo, useState } from 'react';
 import type { CategoryType } from '../api/types';
 import { CATEGORY_ORDER, CATEGORY_LABEL } from '../api/types';
 import BudgetPanel from './BudgetPanel';
+import { formatKRW } from '../utils/format';
 import { simulateMonth } from '../api/simulations';
 
 type Props = {
   sessionId: number;
   initialScores: Record<CategoryType, number>;
+  meta?: { difficulty?: string; initialBudget?: number; treasury?: number };
 };
 
-export default function Dashboard({ sessionId, initialScores }: Props) {
+export default function Dashboard({ sessionId, initialScores, meta }: Props) {
   const [scores, setScores] = useState<Record<CategoryType, number>>(initialScores);
   const [delta, setDelta] = useState<Record<CategoryType, number>>(() => {
     const d: Record<CategoryType, number> = { DEFENSE: 0, DIPLOMACY: 0, ECONOMY: 0, POLITICS: 0, CULTURE: 0, ENVIRONMENT: 0 };
@@ -51,6 +53,21 @@ export default function Dashboard({ sessionId, initialScores }: Props) {
 
   return (
     <div className="row" style={{ gap: 16 }}>
+      <div style={{ gridColumn: '1 / -1' }}>
+        <section>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <strong>세션 #{sessionId}</strong>
+              {meta?.difficulty && <span className="hint" style={{ marginLeft: 8 }}>난이도: {meta.difficulty}</span>}
+            </div>
+            <div className="hint">
+              초기 예산: <strong>{formatKRW(meta?.initialBudget)}</strong>
+              <span style={{ margin: '0 6px' }}>|</span>
+              현재 잔액: <strong>{formatKRW(meta?.treasury)}</strong>
+            </div>
+          </div>
+        </section>
+      </div>
       <div>
         <section>
           <h2>지표 요약</h2>

--- a/frontend/src/pages/DashboardRoute.tsx
+++ b/frontend/src/pages/DashboardRoute.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import Dashboard from '../components/Dashboard';
 import { getLatestReport } from '../api/reports';
 import type { CategoryType } from '../api/types';
+import type { StartSessionResponse } from '../api/sessions';
 
 export default function DashboardRoute() {
   const { id } = useParams();
   const sessionId = Number(id);
+  const location = useLocation();
+  const state = location.state as undefined | { sessionMeta?: StartSessionResponse };
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [scores, setScores] = useState<Record<CategoryType, number> | null>(null);
@@ -45,6 +48,14 @@ export default function DashboardRoute() {
   if (!scores) return null;
 
   return (
-    <Dashboard sessionId={sessionId} initialScores={scores} />
+    <Dashboard
+      sessionId={sessionId}
+      initialScores={scores}
+      meta={state?.sessionMeta ? {
+        difficulty: state.sessionMeta.difficulty,
+        initialBudget: state.sessionMeta.initialBudget,
+        treasury: state.sessionMeta.treasury,
+      } : undefined}
+    />
   );
 }

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NewGameDialog from '../components/NewGameDialog';
+import type { StartSessionResponse } from '../api/sessions';
 
 export default function Landing() {
   const [open, setOpen] = useState(false);
@@ -43,7 +44,9 @@ export default function Landing() {
       <NewGameDialog
         open={open}
         onClose={() => setOpen(false)}
-        onStarted={(res) => navigate(`/sessions/${res.sessionId}`)}
+        onStarted={(res: StartSessionResponse) =>
+          navigate(`/sessions/${res.sessionId}`, { state: { sessionMeta: res } })
+        }
       />
     </>
   );

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,11 @@
+export function formatKRW(amount?: number | null): string {
+  if (amount == null || !Number.isFinite(amount as number)) return '-';
+  try {
+    return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW', maximumFractionDigits: 0 }).format(
+      Number(amount)
+    );
+  } catch {
+    return `${amount}원`;
+  }
+}
+

--- a/src/main/java/com/example/domain/GameSession.java
+++ b/src/main/java/com/example/domain/GameSession.java
@@ -26,6 +26,11 @@ public class GameSession {
 
     private LocalDateTime createdAt;
 
+    // PRD §6 난이도별 초기 예산(원) 및 현재 금고 잔액(원)
+    // 마이그레이션 V2에서 컬럼 추가: initial_budget, treasury
+    private Long initialBudget;
+    private Long treasury;
+
     protected GameSession() {
     }
 
@@ -58,5 +63,21 @@ public class GameSession {
     public void incrementMonth() {
         int cur = this.currentMonth == null ? 0 : this.currentMonth;
         this.currentMonth = cur + 1;
+    }
+
+    public Long getInitialBudget() {
+        return initialBudget;
+    }
+
+    public void setInitialBudget(Long initialBudget) {
+        this.initialBudget = initialBudget;
+    }
+
+    public Long getTreasury() {
+        return treasury;
+    }
+
+    public void setTreasury(Long treasury) {
+        this.treasury = treasury;
     }
 }

--- a/src/main/java/com/example/session/StartSessionService.java
+++ b/src/main/java/com/example/session/StartSessionService.java
@@ -25,6 +25,11 @@ public class StartSessionService {
     @Transactional
     public Result start(Difficulty difficulty) {
         GameSession session = new GameSession(difficulty, 0, LocalDateTime.now());
+
+        long initialBudget = mapInitialBudgetByDifficulty(difficulty);
+        session.setInitialBudget(initialBudget);
+        session.setTreasury(initialBudget);
+
         session = gameSessionRepository.save(session);
 
         EnumMap<CategoryType, Integer> initialScores = new EnumMap<>(CategoryType.class);
@@ -34,13 +39,22 @@ public class StartSessionService {
             categoryScoreRepository.save(new CategoryScore(c, score, session));
         }
 
-        return new Result(session.getId(), difficulty, initialScores);
+        return new Result(session.getId(), difficulty, initialScores, session.getInitialBudget(), session.getTreasury());
     }
 
     public record Result(
             Long sessionId,
             Difficulty difficulty,
-            Map<CategoryType, Integer> scores
+            Map<CategoryType, Integer> scores,
+            Long initialBudget,
+            Long treasury
     ) {}
-}
 
+    private long mapInitialBudgetByDifficulty(Difficulty difficulty) {
+        return switch (difficulty) {
+            case EASY -> 1_500_000_000L;   // 15억 원
+            case NORMAL -> 1_000_000_000L; // 10억 원
+            case HARD -> 800_000_000L;     // 8억 원
+        };
+    }
+}

--- a/src/main/java/com/example/web/SessionsController.java
+++ b/src/main/java/com/example/web/SessionsController.java
@@ -48,7 +48,13 @@ public class SessionsController {
     public ResponseEntity<StartSessionResponse> start(@Validated @RequestBody StartSessionRequest request) {
         Difficulty difficulty = request.getDifficulty();
         var result = startSessionService.start(difficulty);
-        var body = new StartSessionResponse(result.sessionId(), result.difficulty(), result.scores());
+        var body = new StartSessionResponse(
+                result.sessionId(),
+                result.difficulty(),
+                result.scores(),
+                result.initialBudget(),
+                result.treasury()
+        );
         return ResponseEntity.created(URI.create("/api/v1/sessions/" + result.sessionId()))
                 .body(body);
     }

--- a/src/main/java/com/example/web/dto/StartSessionResponse.java
+++ b/src/main/java/com/example/web/dto/StartSessionResponse.java
@@ -13,11 +13,18 @@ public class StartSessionResponse {
     private Difficulty difficulty;
     @Schema(description = "초기 카테고리 점수(0~100)")
     private Map<CategoryType, Integer> scores;
+    @Schema(description = "난이도에 따른 초기 예산(원)")
+    private Long initialBudget;
+    @Schema(description = "현재 금고 잔액(원)")
+    private Long treasury;
 
-    public StartSessionResponse(Long sessionId, Difficulty difficulty, Map<CategoryType, Integer> scores) {
+    public StartSessionResponse(Long sessionId, Difficulty difficulty, Map<CategoryType, Integer> scores,
+                                Long initialBudget, Long treasury) {
         this.sessionId = sessionId;
         this.difficulty = difficulty;
         this.scores = scores;
+        this.initialBudget = initialBudget;
+        this.treasury = treasury;
     }
 
     public Long getSessionId() {
@@ -31,5 +38,12 @@ public class StartSessionResponse {
     public Map<CategoryType, Integer> getScores() {
         return scores;
     }
-}
 
+    public Long getInitialBudget() {
+        return initialBudget;
+    }
+
+    public Long getTreasury() {
+        return treasury;
+    }
+}

--- a/src/main/resources/db/migration/V2__difficulty_params.sql
+++ b/src/main/resources/db/migration/V2__difficulty_params.sql
@@ -1,0 +1,5 @@
+-- V2: 난이도별 초기 예산/금고 컬럼 추가
+ALTER TABLE game_sessions
+    ADD COLUMN IF NOT EXISTS initial_budget BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS treasury BIGINT NOT NULL DEFAULT 0;
+


### PR DESCRIPTION
## 개요\n백엔드(#58)에서 Start Session 응답에 포함된 를 프론트 대시보드에 노출합니다. 새 게임 생성 후 세션 메타를 네비게이션 state로 전달해,  진입 시 상단 바에서 초기 예산/현재 잔액을 보여줍니다.\n\n## 변경 내용\n- typings: StartSessionResponse에 ,  추가\n- Landing → DashboardRoute: 네비게이션 state로 세션 메타 전달\n- Dashboard: 상단에 세션 ID/난이도/초기 예산/현재 잔액 표시(KRW 통화 포맷)\n- util:  추가\n\n## 확인 방법\n1) 백엔드 PR #58 머지/실행\n2) 프론트: 새 게임 시작 →  이동 → 상단 바에서 금액 노출 확인\n\n## 한계/후속\n- 새로고침 시 네비게이션 state가 사라짐 → 이후 세션 메타 API 또는  확장으로 복원 예정\n