### PR TITLE
chore(db): auto-repair Flyway on startup for local/dev/tc

### DIFF
--- a/src/main/java/com/example/config/FlywayRepairConfig.java
+++ b/src/main/java/com/example/config/FlywayRepairConfig.java
@@ -1,0 +1,27 @@
+package com.example.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * 로컬/TC/개발 프로필에서만 Flyway repair를 선행하여
+ * 체크섬 변경(개발 중 마이그레이션 수정)으로 인한 검증 실패를 자동 치유한다.
+ * 운영(prod)에는 적용하지 않는다.
+ */
+@Configuration
+@Profile({"local", "tc", "dev"})
+public class FlywayRepairConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayRepairThenMigrate() {
+        return (Flyway flyway) -> {
+            // 기존 이력의 checksum을 현재 스크립트로 정정 후 마이그레이션 수행
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}
+


### PR DESCRIPTION
## 배경\nV2 마이그레이션 수정으로 로컬 DB에 기존 체크섬과 불일치가 발생하면서 애플리케이션 부팅 시 Flyway validation 에러가 나고 있습니다.\n\n## 변경\n-  (local/dev/tc 프로필 한정)\n  - 부팅 시  후  수행\n  - 운영(prod)에는 적용하지 않음\n\n## 효과\n- 개발 환경에서 마이그레이션 스크립트 수정 이후에도 부팅이 가능(기존 이력 checksum 정정)\n- 테스트/TC/H2 환경에도 안전하게 적용 가능\n\n## 대안\n- DB 초기화() 또는 수동  실행\n